### PR TITLE
feat: Executor

### DIFF
--- a/core/src/main/java/gay/oss/gatos/core/executor/GraphExecutor.java
+++ b/core/src/main/java/gay/oss/gatos/core/executor/GraphExecutor.java
@@ -1,0 +1,65 @@
+package gay.oss.gatos.core.executor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.Unmodifiable;
+
+import gay.oss.gatos.core.graph.Node;
+import gay.oss.gatos.core.graph.NodeCategory;
+import gay.oss.gatos.core.graph.connector.NodeConnection;
+import gay.oss.gatos.core.graph.data.DataBox;
+
+//TODO cleanup
+public class GraphExecutor {
+    private final @Unmodifiable List<Node> nodes;
+    private final @Unmodifiable Collection<Node> outputNodes;
+    private final @Unmodifiable Collection<NodeConnection<?>> connections;
+    private final @Unmodifiable Map<Node, Collection<NodeConnection<?>>> nodeDependencies;
+
+    public GraphExecutor(List<Node> nodes, Set<NodeConnection<?>> connections) {
+        this.nodes = List.copyOf(nodes);
+        this.outputNodes = nodes.stream().filter(n -> n.type().category() == NodeCategory.OUTPUT).toList();
+        this.connections = List.copyOf(connections);
+        this.nodeDependencies = this.nodes.stream().collect(Collectors.toMap(
+            Function.identity(),
+            n -> n.inputs().values().stream().flatMap(connector -> this.connections.stream().filter(connection -> connection.to().equals(connector))).toList()
+        ));
+    }
+
+    public Runnable execute() {
+        Map<NodeConnection<?>, CompletableFuture<DataBox<?>>> results = new ConcurrentHashMap<>();
+
+        return () -> {
+            for (var node : this.nodes) {
+                var res = this.resultOfNode(node, results);
+                results.putAll(res);
+            }
+        };
+    }
+
+    private Map<NodeConnection<?>, CompletableFuture<DataBox<?>>> resultOfNode(
+        Node node,
+        Map<NodeConnection<?>, CompletableFuture<DataBox<?>>> allResults
+    ) {
+        Map<String, DataBox<?>> inputs = new HashMap<>();
+        for (var dep : this.nodeDependencies.get(node)) {
+            var resForDep = allResults.get(dep);
+            var depInputName = dep.to().name();
+            inputs.put(depInputName, resForDep.join());
+        }
+
+        return node.type().compute(inputs, node.settings()).entrySet().stream().collect(Collectors.toMap(e -> this.getOutputConnectionByName(node, e.getKey()), Map.Entry::getValue));
+    }
+
+    private NodeConnection<?> getOutputConnectionByName(Node node, String name) {
+        return node.getOutputWithName(name).flatMap(c -> this.connections.stream().filter(a -> a.from().equals(c)).findAny()).orElseThrow();
+    }
+}

--- a/core/src/main/java/gay/oss/gatos/core/graph/Graph.java
+++ b/core/src/main/java/gay/oss/gatos/core/graph/Graph.java
@@ -149,6 +149,14 @@ public class Graph {
     }
 
     /**
+     * Returns a copy of the set of all connections in this graph.
+     * @return the connections in this graph
+     */
+    public Set<NodeConnection<?>> getConnections() {
+        return new HashSet<>(this.connections);
+    }
+
+    /**
      * Retrieves all connections associated with a node UUID. Returns an empty set if there is no node with the given UUID.
      * @param nodeId    the node UUID
      * @return          all connections associated with the node with the UUID

--- a/core/src/main/java/gay/oss/gatos/core/graph/NodeType.java
+++ b/core/src/main/java/gay/oss/gatos/core/graph/NodeType.java
@@ -3,6 +3,7 @@ package gay.oss.gatos.core.graph;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import gay.oss.gatos.core.graph.connector.NodeConnector;
 import gay.oss.gatos.core.graph.data.DataBox;
@@ -38,4 +39,12 @@ public interface NodeType {
      * @return the settings for a node of this type
      */
     Map<String, DataBox<?>> settings();
+
+    /**
+     * (Asynchronously) compute the outputs of this node in a map of output connector name to value.
+     * @param inputs    a map of input connector name to value
+     * @param settings  a map of node settings
+     * @return          a CompletableFuture of each output in a map by name
+     */
+    Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings);
 }

--- a/core/src/main/java/gay/oss/gatos/core/graph/data/DataBox.java
+++ b/core/src/main/java/gay/oss/gatos/core/graph/data/DataBox.java
@@ -1,5 +1,8 @@
 package gay.oss.gatos.core.graph.data;
 
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * Holds (boxes) a value and a reference to its type.
  * @param value the value stored
@@ -15,5 +18,24 @@ public record DataBox<T>(T value, DataType<T> type) {
      */
     public DataBox<T> withValue(T value) {
         return new DataBox<>(value, this.type);
+    }
+
+    /**
+     * Retrieves a data value of a certain type from a map. Returns an empty optional if the
+     * value does not exist or is not of the expected type.
+     * @param boxes the map
+     * @param key   the key
+     * @param type  the expected datatype
+     * @param <K>   the type of the key
+     * @param <T>   the type of the data
+     * @return      an Optional of the value, or empty
+     */
+    public static <K, T> Optional<T> get(Map<K, DataBox<?>> boxes, K key, DataType<T> type) {
+        var res = boxes.get(key);
+        if (res != null && res.type == type) {
+            //noinspection unchecked
+            return Optional.of((T) res.value());
+        }
+        return Optional.empty();
     }
 }

--- a/core/src/test/java/gay/oss/gatos/core/executor/test/GraphExecutorTest.java
+++ b/core/src/test/java/gay/oss/gatos/core/executor/test/GraphExecutorTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gay/oss/gatos/core/executor/test/GraphExecutorTest.java
+++ b/core/src/test/java/gay/oss/gatos/core/executor/test/GraphExecutorTest.java
@@ -1,0 +1,255 @@
+package gay.oss.gatos.core.executor.test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import gay.oss.gatos.core.executor.GraphExecutor;
+import gay.oss.gatos.core.graph.Graph;
+import gay.oss.gatos.core.graph.Node;
+import gay.oss.gatos.core.graph.NodeCategory;
+import gay.oss.gatos.core.graph.NodeType;
+import gay.oss.gatos.core.graph.connector.NodeConnection;
+import gay.oss.gatos.core.graph.connector.NodeConnector;
+import gay.oss.gatos.core.graph.data.DataBox;
+import gay.oss.gatos.core.graph.data.DataType;
+
+public class GraphExecutorTest {
+    private static final NodeType ADD_INTS = new AddIntNodeType();
+    private static final NodeType ADD_INTS_SLOWLY = new AddIntNodeType();
+    private static final NodeType INPUT_INT = new InputIntNodeType();
+
+    @Test
+    public void simpleGraphComputesCorrectly() {
+        var graph = new Graph();
+        AtomicInteger result = new AtomicInteger();
+        var input = graph.addNode(INPUT_INT);
+        graph.modifyNode(input.id(), node -> node.modifySetting("value", 10));
+        var output = graph.addNode(new OutputIntNodeType(result));
+
+        var adder = graph.addNode(ADD_INTS);
+        graph.modifyNode(adder.id(), node -> node.modifySetting("value_to_add", 5));
+
+        var conn = NodeConnection.createConnection(
+            input, "out",
+            adder, "in",
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+
+        conn = NodeConnection.createConnection(
+            adder, "out",
+            output, "in",
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+
+        var executionOrderedNodes = graph.getExecutionOrder();
+        Assertions.assertTrue(executionOrderedNodes.isPresent());
+        var graphExecutor = new GraphExecutor(executionOrderedNodes.get(), graph.getConnections());
+
+        CompletableFuture.runAsync(graphExecutor.execute()).join();
+        Assertions.assertEquals(15, result.get());
+    }
+
+    @Test
+    public void slowGraphComputesCorrectly() {
+        var graph = new Graph();
+        AtomicInteger result = new AtomicInteger();
+        var input = graph.addNode(INPUT_INT);
+        graph.modifyNode(input.id(), node -> node.modifySetting("value", 10));
+        var output = graph.addNode(new OutputIntNodeType(result));
+
+        var adder = graph.addNode(ADD_INTS_SLOWLY);
+        graph.modifyNode(adder.id(), node -> node.modifySetting("value_to_add", 5));
+
+        var conn = NodeConnection.createConnection(
+            input, "out",
+            adder, "in",
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+
+        conn = NodeConnection.createConnection(
+            adder, "out",
+            output, "in",
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+
+        var executionOrderedNodes = graph.getExecutionOrder();
+        Assertions.assertTrue(executionOrderedNodes.isPresent());
+        var graphExecutor = new GraphExecutor(executionOrderedNodes.get(), graph.getConnections());
+
+        CompletableFuture.runAsync(graphExecutor.execute()).join();
+        Assertions.assertEquals(15, result.get());
+    }
+
+    private static final class AddIntNodeType implements NodeType {
+        @Override
+        public NodeCategory category() {
+            return NodeCategory.PROCESS;
+        }
+
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of(
+                "value_to_add", DataType.INTEGER.create(0)
+            );
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of(
+                "out", CompletableFuture.completedFuture(DataType.INTEGER.create(
+                        DataBox.get(settings, "value_to_add", DataType.INTEGER).orElseThrow()
+                        + DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow()
+                    ))
+            );
+        }
+    }
+
+    private static final class SlowlyAddIntNodeType implements NodeType {
+        @Override
+        public NodeCategory category() {
+            return NodeCategory.PROCESS;
+        }
+
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of(
+                "value_to_add", DataType.INTEGER.create(0)
+            );
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of(
+                "out", CompletableFuture.supplyAsync(this.addIntsSlowly(
+                    DataBox.get(settings, "value_to_add", DataType.INTEGER).orElseThrow(),
+                    DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow()
+                )
+            ));
+        }
+
+        private Supplier<DataBox<?>> addIntsSlowly(int a, int b) {
+            return () -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return DataType.INTEGER.create(a + b);
+            };
+        }
+    }
+
+    private static final class InputIntNodeType implements NodeType {
+        @Override
+        public NodeCategory category() {
+            return NodeCategory.PUSHED_INPUT;
+        }
+
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of();
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of(
+                "value", DataType.INTEGER.create(0)
+            );
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of(
+                "out", CompletableFuture.completedFuture(DataType.INTEGER.create(DataBox.get(settings, "value", DataType.INTEGER).orElseThrow()))
+            );
+        }
+    }
+
+    private static final class OutputIntNodeType implements NodeType {
+        public final AtomicInteger result;
+
+        // obviously outside of tests we would not be instantiating node types multiple times...
+        private OutputIntNodeType(AtomicInteger result) {
+            this.result = result;
+        }
+
+        @Override
+        public NodeCategory category() {
+            return NodeCategory.OUTPUT;
+        }
+
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of();
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            this.result.set(DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow());
+            return Map.of();
+        }
+    }
+}

--- a/core/src/test/java/gay/oss/gatos/core/executor/test/GraphExecutorTest.java
+++ b/core/src/test/java/gay/oss/gatos/core/executor/test/GraphExecutorTest.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
@@ -24,6 +25,7 @@ import gay.oss.gatos.core.graph.data.DataType;
 public class GraphExecutorTest {
     private static final NodeType ADD_INTS = new AddIntNodeType();
     private static final NodeType ADD_INTS_SLOWLY = new AddIntNodeType();
+    private static final NodeType ADD_INTS_2INPUT = new AddIntTwoInputNodeType();
     private static final NodeType INPUT_INT = new InputIntNodeType();
 
     @Test
@@ -96,6 +98,56 @@ public class GraphExecutorTest {
         Assertions.assertEquals(15, result.get());
     }
 
+    @Test
+    public void complexGraphComputesCorrectly() {
+        var graph = new Graph();
+        AtomicInteger result = new AtomicInteger();
+        var output = graph.addNode(new OutputIntNodeType(result));
+
+        var inputs = IntStream.of(2, 4, 8, 16, 2)
+            .mapToObj(i -> {
+                var input = graph.addNode(INPUT_INT);
+                return graph.modifyNode(input.id(), node -> node.modifySetting("value", i));
+            })
+            .toList();
+
+        var adder1 = graph.addNode(ADD_INTS_2INPUT);
+        var adder2 = graph.addNode(ADD_INTS_2INPUT);
+        var adder3 = graph.addNode(ADD_INTS_2INPUT);
+        var adder4 = graph.addNode(ADD_INTS_2INPUT);
+
+        connectInt(graph, inputs.get(1), "out", adder1, "in1");
+        connectInt(graph, inputs.get(2), "out", adder1, "in2");
+
+        connectInt(graph, inputs.get(3), "out", adder2, "in1");
+        connectInt(graph, inputs.get(4), "out", adder2, "in2");
+
+        connectInt(graph, adder1, "out", adder3, "in1");
+        connectInt(graph, adder2, "out", adder3, "in2");
+
+        connectInt(graph, adder3, "out", adder4, "in1");
+        connectInt(graph, inputs.get(0), "out", adder4, "in2");
+
+        connectInt(graph, adder4, "out", output, "in");
+
+        var executionOrderedNodes = graph.getExecutionOrder();
+        Assertions.assertTrue(executionOrderedNodes.isPresent());
+        var graphExecutor = new GraphExecutor(executionOrderedNodes.get(), graph.getConnections());
+
+        CompletableFuture.runAsync(graphExecutor.execute()).join();
+        Assertions.assertEquals(32, result.get());
+    }
+
+    private static void connectInt(Graph graph, Node a, String connectorA, Node b, String connectorB) {
+        var conn = NodeConnection.createConnection(
+            a, connectorA,
+            b, connectorB,
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+    }
+
     private static final class AddIntNodeType implements NodeType {
         @Override
         public NodeCategory category() {
@@ -130,6 +182,43 @@ public class GraphExecutorTest {
                         DataBox.get(settings, "value_to_add", DataType.INTEGER).orElseThrow()
                         + DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow()
                     ))
+            );
+        }
+    }
+
+    private static final class AddIntTwoInputNodeType implements NodeType {
+        @Override
+        public NodeCategory category() {
+            return NodeCategory.PROCESS;
+        }
+
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Input<>(nodeId, "in1", DataType.INTEGER),
+                new NodeConnector.Input<>(nodeId, "in2", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER)
+            );
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of(
+                "out", CompletableFuture.completedFuture(DataType.INTEGER.create(
+                    DataBox.get(inputs, "in1", DataType.INTEGER).orElseThrow()
+                        + DataBox.get(inputs, "in2", DataType.INTEGER).orElseThrow()
+                ))
             );
         }
     }

--- a/core/src/test/java/gay/oss/gatos/core/graph/test/GraphTest.java
+++ b/core/src/test/java/gay/oss/gatos/core/graph/test/GraphTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
@@ -276,6 +277,11 @@ public class GraphTest {
                     "setting_1", DataType.INTEGER.create(0)
             );
         }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of();
+        }
     }
 
     private static final class TestInputNodeType implements NodeType {
@@ -300,6 +306,11 @@ public class GraphTest {
         public Map<String, DataBox<?>> settings() {
             return Map.of();
         }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of();
+        }
     }
 
     private static final class TestOutputNodeType implements NodeType {
@@ -322,6 +333,11 @@ public class GraphTest {
 
         @Override
         public Map<String, DataBox<?>> settings() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
             return Map.of();
         }
     }

--- a/core/src/test/java/gay/oss/gatos/core/graph/test/GraphTest.java
+++ b/core/src/test/java/gay/oss/gatos/core/graph/test/GraphTest.java
@@ -1,5 +1,7 @@
 package gay.oss.gatos.core.graph.test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -169,6 +171,83 @@ public class GraphTest {
         graph.addConnection(conn.get());
 
         Assertions.assertTrue(graph.validate());
+    }
+
+    @Test
+    public void graphWithLongerPathAndExtraNodesIsValid() {
+        var graph = new Graph();
+        var input = graph.addNode(INPUT_NODE_TYPE);
+        var output = graph.addNode(OUTPUT_NODE_TYPE);
+
+        @Nullable Node lastNode = null;
+        for (int i = 0; i < 10; i++) {
+            var intermediary = graph.addNode(TEST_NODE_TYPE);
+            var conn = NodeConnection.createConnection(
+                lastNode == null ? input : lastNode, "out",
+                intermediary, "in",
+                DataType.INTEGER
+            );
+            Assertions.assertTrue(conn.isPresent());
+            graph.addConnection(conn.get());
+
+            lastNode = intermediary;
+        }
+
+        var conn = NodeConnection.createConnection(
+            lastNode, "out",
+            output, "in",
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+
+        for (int i = 0; i < 10; i++) {
+            graph.addNode(TEST_NODE_TYPE);
+        }
+
+        Assertions.assertTrue(graph.validate());
+    }
+
+    @Test
+    public void graphHasCorrectPath() {
+        var graph = new Graph();
+        var input = graph.addNode(INPUT_NODE_TYPE);
+        var output = graph.addNode(OUTPUT_NODE_TYPE);
+        List<Node> list = new ArrayList<>();
+        list.add(input);
+
+        @Nullable Node lastNode = null;
+        for (int i = 0; i < 10; i++) {
+            var intermediary = graph.addNode(TEST_NODE_TYPE);
+            var conn = NodeConnection.createConnection(
+                lastNode == null ? input : lastNode, "out",
+                intermediary, "in",
+                DataType.INTEGER
+            );
+            Assertions.assertTrue(conn.isPresent());
+            graph.addConnection(conn.get());
+
+            lastNode = intermediary;
+            list.add(intermediary);
+        }
+
+        var conn = NodeConnection.createConnection(
+            lastNode, "out",
+            output, "in",
+            DataType.INTEGER
+        );
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+
+        list.add(output);
+
+        for (int i = 0; i < 10; i++) {
+            graph.addNode(TEST_NODE_TYPE);
+        }
+
+        var sorted = graph.getExecutionOrder();
+        Assertions.assertTrue(sorted.isPresent());
+        Assertions.assertEquals(list, sorted.get());
     }
 
     private static final class TestNodeType implements NodeType {

--- a/core/src/test/java/gay/oss/gatos/core/graph/test/NodeTest.java
+++ b/core/src/test/java/gay/oss/gatos/core/graph/test/NodeTest.java
@@ -3,6 +3,7 @@ package gay.oss.gatos.core.graph.test;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,11 @@ public class NodeTest {
                     "setting_1", DataType.INTEGER.create(0),
                     "setting_2", DataType.BOOLEAN.create(false)
             );
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
+            return Map.of();
         }
     }
 }


### PR DESCRIPTION
Adds the GraphExecutor, which executes graphs.

The GraphExecutor constructor takes two arguments: one is the result of `graph.executionOrder()`, the other is `graph.getConnections()`.

The GraphExecutor has a method `execute` which produces a runnable. Running that runnable will run the flow.