### PR TITLE
chore: basic nodes module

### DIFF
--- a/basic_nodes/build.gradle
+++ b/basic_nodes/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'multimodule-config'
+}
+
+group = 'gay.oss.gatos'
+version = '0.0.1-SNAPSHOT'
+
+dependencies {
+    implementation project(":core")
+
+    // Tests
+    testImplementation(platform('org.junit:junit-bom:5.9.2'))
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/basic_nodes/src/main/java/gay/oss/gatos/basicnodes/package_info.java
+++ b/basic_nodes/src/main/java/gay/oss/gatos/basicnodes/package_info.java
@@ -1,0 +1,1 @@
+package gay.oss.gatos.basicnodes;

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = "Gatos Backend"
 
 include "api"
 include "core"
+include "basic_nodes"


### PR DESCRIPTION
gradle module name: `basic_nodes`

package name: `gay.oss.gatos.basicnodes`

this module will store things like string modification nodes, maths nodes, etc. essentially any node which doesn't have to interface with some external service

added a package_info.java so that the dir structure is preserved by git