### PR TITLE
feat: a lot of datatype improvements

### DIFF
--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringLengthNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringLengthNodeType.java
@@ -25,12 +25,12 @@ public class StringLengthNodeType extends NodeType.Process {
     @Override
     public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
         return Set.of(
-            new NodeConnector.Output<>(nodeId, "output", DataType.INTEGER));
+            new NodeConnector.Output<>(nodeId, "output", DataType.NUMBER));
     }
 
     @Override
     public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
         var inputStr = DataBox.get(inputs, "input", DataType.STRING).orElse("");
-        return Map.of("output", CompletableFuture.completedFuture(DataType.INTEGER.create(inputStr.length())));
+        return Map.of("output", CompletableFuture.completedFuture(DataType.NUMBER.create((double) inputStr.length())));
     }
 }

--- a/basic_nodes/src/test/java/club/mondaylunch/gatos/basicnodes/test/StringLengthNodeTest.java
+++ b/basic_nodes/src/test/java/club/mondaylunch/gatos/basicnodes/test/StringLengthNodeTest.java
@@ -33,13 +33,13 @@ public class StringLengthNodeTest {
             "input", DataType.STRING.create(TEST_STR)
         );
         var output = BasicNodes.STRING_LENGTH.compute(input, Map.of());
-        Assertions.assertEquals(output.get("output").join().value(), 44);
+        Assertions.assertEquals(44.0, output.get("output").join().value());
     }
 
     @Test
     public void correctlyBehavesForIncorrectInputs() {
         Map<String, DataBox<?>> input0 = Map.of();
         var output0 = BasicNodes.STRING_LENGTH.compute(input0, Map.of());
-        Assertions.assertEquals(output0.get("output").join().value(), 0);
+        Assertions.assertEquals(0.0, output0.get("output").join().value());
     }
 }

--- a/basic_nodes/src/test/java/club/mondaylunch/gatos/basicnodes/test/VariableExtractionNodeTest.java
+++ b/basic_nodes/src/test/java/club/mondaylunch/gatos/basicnodes/test/VariableExtractionNodeTest.java
@@ -18,10 +18,10 @@ import club.mondaylunch.gatos.core.graph.Node;
 
 public class VariableExtractionNodeTest {
     private static final class TestJSONExtractionClass {
-        private final int testInt = 420;
+        private final double testNumber = 420;
         private final boolean testBoolean = true;
         private final String testString = "tickles";
-        private final Collection<Integer> testIntCollection = List.of(0, 1, 2, 3);
+        private final Collection<Double> testNumberCollection = List.of(0., 1., 2., 3.);
         private final Collection<String> testStrCollection = List.of("b", "r", "u", "h");
         private final Collection<JsonObject> testJsonObjCollection = List.of(new JsonObject(), new JsonObject());
     }
@@ -45,15 +45,15 @@ public class VariableExtractionNodeTest {
     }
 
     @Test
-    public void correctlyExtractsInt() {
+    public void correctlyExtractsNumber() {
         var node = Node.create(BasicNodes.VARIABLE_EXTRACTION)
-            .modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.INTEGER));
+            .modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.NUMBER));
         Map<String, DataBox<?>> input = Map.of(
             "input", DataType.JSON_OBJECT.create(TEST_JSON_OBJECT),
-            "key", DataType.STRING.create("testInt")
+            "key", DataType.STRING.create("testNumber")
         );
         var result = BasicNodes.VARIABLE_EXTRACTION.compute(input, node.settings());
-        Assertions.assertEquals(result.get("output").join().value(), Optional.of(new TestJSONExtractionClass().testInt));
+        Assertions.assertEquals(Optional.of(new TestJSONExtractionClass().testNumber), result.get("output").join().value());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class VariableExtractionNodeTest {
             "key", DataType.STRING.create("testBoolean")
         );
         var result = BasicNodes.VARIABLE_EXTRACTION.compute(input, node.settings());
-        Assertions.assertEquals(result.get("output").join().value(), Optional.of(new TestJSONExtractionClass().testBoolean));
+        Assertions.assertEquals(Optional.of(new TestJSONExtractionClass().testBoolean), result.get("output").join().value());
     }
 
     @Test
@@ -77,19 +77,19 @@ public class VariableExtractionNodeTest {
             "key", DataType.STRING.create("testString")
         );
         var result = BasicNodes.VARIABLE_EXTRACTION.compute(input, node.settings());
-        Assertions.assertEquals(result.get("output").join().value(), Optional.of(new TestJSONExtractionClass().testString));
+        Assertions.assertEquals(Optional.of(new TestJSONExtractionClass().testString), result.get("output").join().value());
     }
 
     @Test
     public void correctlyExtractsCollection() {
         var node = Node.create(BasicNodes.VARIABLE_EXTRACTION)
-            .modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.INTEGER.listOf()));
+            .modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.NUMBER.listOf()));
         Map<String, DataBox<?>> input = Map.of(
             "input", DataType.JSON_OBJECT.create(TEST_JSON_OBJECT),
-            "key", DataType.STRING.create("testIntCollection")
+            "key", DataType.STRING.create("testNumberCollection")
         );
         var result = BasicNodes.VARIABLE_EXTRACTION.compute(input, node.settings());
-        Assertions.assertEquals(result.get("output").join().value(), new TestJSONExtractionClass().testIntCollection);
+        Assertions.assertEquals(new TestJSONExtractionClass().testNumberCollection, result.get("output").join().value());
 
         node.modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.STRING.listOf()));
         Map<String, DataBox<?>> inputStr = Map.of(
@@ -97,7 +97,7 @@ public class VariableExtractionNodeTest {
             "key", DataType.STRING.create("testStrCollection")
         );
         var resultStr = BasicNodes.VARIABLE_EXTRACTION.compute(inputStr, node.settings());
-        Assertions.assertEquals(resultStr.get("output").join().value(), new TestJSONExtractionClass().testStrCollection);
+        Assertions.assertEquals(new TestJSONExtractionClass().testStrCollection, resultStr.get("output").join().value());
 
         node.modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.JSON_OBJECT.listOf()));
         Map<String, DataBox<?>> inputJson = Map.of(
@@ -105,19 +105,19 @@ public class VariableExtractionNodeTest {
             "key", DataType.STRING.create("testJsonObjCollection")
         );
         var resultJson = BasicNodes.VARIABLE_EXTRACTION.compute(inputJson, node.settings());
-        Assertions.assertEquals(resultJson.get("output").join().value(), new TestJSONExtractionClass().testJsonObjCollection);
+        Assertions.assertEquals(new TestJSONExtractionClass().testJsonObjCollection, resultJson.get("output").join().value());
     }
 
     @Test
     public void correctlyExtractsIndividualAsCollection() {
         var node = Node.create(BasicNodes.VARIABLE_EXTRACTION)
-            .modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.INTEGER.listOf()));
+            .modifySetting("output_type", VariableExtractionNodeType.getReturnBoxFromType(DataType.NUMBER.listOf()));
         Map<String, DataBox<?>> input = Map.of(
             "input", DataType.JSON_OBJECT.create(TEST_JSON_OBJECT),
-            "key", DataType.STRING.create("testInt")
+            "key", DataType.STRING.create("testNumber")
         );
         var result = BasicNodes.VARIABLE_EXTRACTION.compute(input, node.settings());
-        Assertions.assertEquals(result.get("output").join().value(), List.of(new TestJSONExtractionClass().testInt));
+        Assertions.assertEquals(List.of(new TestJSONExtractionClass().testNumber), result.get("output").join().value());
     }
 
     @Test
@@ -128,18 +128,18 @@ public class VariableExtractionNodeTest {
             "key", DataType.STRING.create("notAValidKey")
         );
         var result0 = BasicNodes.VARIABLE_EXTRACTION.compute(input0, node.settings());
-        Assertions.assertEquals(result0.get("output").join().value(), Optional.empty());
+        Assertions.assertEquals(Optional.empty(), result0.get("output").join().value());
 
         Map<String, DataBox<?>> input1 = Map.of(
-            "key", DataType.STRING.create("testInt")
+            "key", DataType.STRING.create("testNumber")
         );
         var result1 = BasicNodes.VARIABLE_EXTRACTION.compute(input1, node.settings());
-        Assertions.assertEquals(result1.get("output").join().value(), Optional.empty());
+        Assertions.assertEquals(Optional.empty(), result1.get("output").join().value());
 
         Map<String, DataBox<?>> input2 = Map.of(
             "input", DataType.JSON_OBJECT.create(TEST_JSON_OBJECT)
         );
         var result2 = BasicNodes.VARIABLE_EXTRACTION.compute(input2, node.settings());
-        Assertions.assertEquals(result2.get("output").join().value(), Optional.empty());
+        Assertions.assertEquals(Optional.empty(), result2.get("output").join().value());
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/Database.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/Database.java
@@ -1,5 +1,6 @@
 package club.mondaylunch.gatos.core;
 
+import club.mondaylunch.gatos.core.codec.DataBoxCodecProvider;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
@@ -68,7 +69,8 @@ public enum Database {
                 NodeConnectionCodecProvider.INSTANCE,
                 GraphCodecProvider.INSTANCE,
                 NodeCodecProvider.INSTANCE,
-                RegistryObjectCodec.Provider.INSTANCE
+                RegistryObjectCodec.Provider.INSTANCE,
+                DataBoxCodecProvider.INSTANCE
             ),
             ClassModelRegistry.createCodecRegistry(),
             MongoClientSettings.getDefaultCodecRegistry()

--- a/core/src/main/java/club/mondaylunch/gatos/core/Database.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/Database.java
@@ -1,6 +1,5 @@
 package club.mondaylunch.gatos.core;
 
-import club.mondaylunch.gatos.core.codec.DataBoxCodecProvider;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
@@ -16,6 +15,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
 import club.mondaylunch.gatos.core.codec.ClassModelRegistry;
+import club.mondaylunch.gatos.core.codec.DataBoxCodecProvider;
 import club.mondaylunch.gatos.core.codec.GraphCodecProvider;
 import club.mondaylunch.gatos.core.codec.NodeCodecProvider;
 import club.mondaylunch.gatos.core.codec.NodeConnectionCodecProvider;

--- a/core/src/main/java/club/mondaylunch/gatos/core/Registry.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/Registry.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 
 public class Registry<T> {
-    public static final RegistryRegistry REGISTRIES = new RegistryRegistry();
+    public static final Registry<Registry<?>> REGISTRIES = new Registry<>(Registry.class);
     private final Map<String, T> map = new HashMap<>();
     private final Map<T, String> reverseMap = new HashMap<>();
     private final Class<? super T> clazz;
@@ -101,36 +101,16 @@ public class Registry<T> {
     }
 
     /**
-     * A registry that holds registries, that also allows lookup by class.
+     * Find a registry that holds values of a given class.
+     * @param clazz the class
+     * @param <T>   the type
+     * @return      a registry that holds the type given, or empty
      */
-    public static class RegistryRegistry extends Registry<Registry<?>> {
-        private final Map<Class<?>, Registry<?>> registriesByClass = new HashMap<>();
-
-        private RegistryRegistry() {
-            super(Registry.class);
-        }
-
-        @Override
-        public <E extends Registry<?>> E register(@NotNull String name, @NotNull E value) {
-            this.registriesByClass.put(value.getClazz(), value);
-            return super.register(name, value);
-        }
-
-        @Override
-        public void clear() {
-            super.clear();
-            this.registriesByClass.clear();
-        }
-
-        /**
-         * Gets a registry by the class of the objects it holds.
-         * @param clazz the class held by the wanted registry
-         * @param <E>   the type held by the wanted registry
-         * @return      the registry that holds objects of the given class
-         */
-        @SuppressWarnings("unchecked")
-        public <E> Optional<Registry<E>> getByClass(Class<E> clazz) {
-            return Optional.ofNullable((Registry<E>) this.registriesByClass.get(clazz));
-        }
+    @SuppressWarnings("unchecked")
+    public static <T, R> Optional<Registry<R>> getRegistryByClass(Class<T> clazz) {
+        return REGISTRIES.getValues().stream()
+            .filter(r -> r.getClazz().isAssignableFrom(clazz))
+            .map(r -> (Registry<R>) r)
+            .findAny();
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodec.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodec.java
@@ -1,0 +1,87 @@
+package club.mondaylunch.gatos.core.codec;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.CollectionCodecProvider;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.Encoder;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.Parameterizable;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import club.mondaylunch.gatos.core.data.DataBox;
+import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.ListDataType;
+import club.mondaylunch.gatos.core.data.OptionalDataType;
+
+public class DataBoxCodec implements Codec<DataBox<?>> {
+    private final CodecRegistry registry;
+
+    public DataBoxCodec(CodecRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public DataBox<?> decode(BsonReader reader, DecoderContext decoderContext) {
+        reader.readStartDocument();
+        reader.readName("type");
+        DataType<?> type = decoderContext.decodeWithChildContext(this.registry.get(DataType.class), reader);
+        reader.readName("value");
+        return this.decodeValue(reader, type, decoderContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void encode(BsonWriter writer, DataBox<?> value, EncoderContext encoderContext) {
+        writer.writeStartDocument();
+        writer.writeName("type");
+        encoderContext.encodeWithChildContext((Codec<DataType<?>>) this.registry.get(value.type().getClass()), writer, value.type());
+        writer.writeName("value");
+        this.encodeValue(writer, value, encoderContext);
+        writer.writeEndDocument();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void encodeValue(BsonWriter writer, DataBox<?> box, EncoderContext encoderContext) {
+        DataType<?> type = box.type();
+        Encoder<?> encoder;
+        Object toEncode;
+        if (type instanceof ListDataType<?> listType) {
+            encoder = ((Parameterizable) new CollectionCodecProvider().get(listType.clazz(), this.registry))
+                .parameterize(this.registry, List.of(listType.contains().clazz()));
+            toEncode = box.value();
+        } else if (type instanceof OptionalDataType<?> optType) {
+            encoder = this.registry.get(optType.contains().clazz());
+            toEncode = ((Optional<?>) box.value()).orElse(null);
+        } else {
+            encoder = this.registry.get(type.clazz());
+            toEncode = box.value();
+        }
+        encoderContext.encodeWithChildContext((Encoder<Object>) encoder, writer, toEncode);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> DataBox<?> decodeValue(BsonReader reader, DataType<?> type, DecoderContext decoderContext) {
+        if (type instanceof ListDataType<?> listType) {
+            var codec = ((Parameterizable) new CollectionCodecProvider().get(listType.clazz(), this.registry))
+                .parameterize(this.registry, List.of(listType.contains().clazz()));
+            return ((DataType<T>) type).create((T) decoderContext.decodeWithChildContext(codec, reader));
+        } else if (type instanceof OptionalDataType<?> optType) {
+            var codec = this.registry.get(optType.contains().clazz());
+            return ((DataType<Optional<T>>) type).create(Optional.ofNullable((T) decoderContext.decodeWithChildContext(codec, reader)));
+        } else {
+            var codec = this.registry.get(type.clazz());
+            return ((DataType<T>) type).create((T) decoderContext.decodeWithChildContext(codec, reader));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<DataBox<?>> getEncoderClass() {
+        return (Class<DataBox<?>>) (Object) DataBox.class;
+    }
+}

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodec.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodec.java
@@ -31,7 +31,9 @@ public class DataBoxCodec implements Codec<DataBox<?>> {
         reader.readName("type");
         DataType<?> type = decoderContext.decodeWithChildContext(this.registry.get(DataType.class), reader);
         reader.readName("value");
-        return this.decodeValue(reader, type, decoderContext);
+        var value = this.decodeValue(reader, type, decoderContext);
+        reader.readEndDocument();
+        return value;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodecProvider.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodecProvider.java
@@ -1,9 +1,10 @@
 package club.mondaylunch.gatos.core.codec;
 
-import club.mondaylunch.gatos.core.data.DataBox;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
+
+import club.mondaylunch.gatos.core.data.DataBox;
 
 public enum DataBoxCodecProvider implements CodecProvider {
 

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodecProvider.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/DataBoxCodecProvider.java
@@ -1,0 +1,21 @@
+package club.mondaylunch.gatos.core.codec;
+
+import club.mondaylunch.gatos.core.data.DataBox;
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+
+public enum DataBoxCodecProvider implements CodecProvider {
+
+    INSTANCE;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
+        if (DataBox.class.isAssignableFrom(clazz)) {
+            return (Codec<T>) new DataBoxCodec(registry);
+        } else {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/NodeConnectorCodec.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/NodeConnectorCodec.java
@@ -28,25 +28,25 @@ public class NodeConnectorCodec implements Codec<NodeConnector<?>> {
     @Override
     public NodeConnector<?> decode(BsonReader reader, DecoderContext decoderContext) {
         Codec<UUID> uuidCodec = this.registry.get(UUID.class);
-        reader.readStartDocument();
-        UUID nodeId = decoderContext.decodeWithChildContext(uuidCodec, reader);
-        String name = reader.readString();
-        DataType<?> dataType = decoderContext.decodeWithChildContext(this.registry.get(DataType.class), reader);
-        reader.readEndDocument();
-        return this.createNodeConnector(nodeId, name, dataType);
+        return SerializationUtils.readDocument(reader, () -> {
+            UUID nodeId = decoderContext.decodeWithChildContext(uuidCodec, reader);
+            String name = reader.readString();
+            DataType<?> dataType = decoderContext.decodeWithChildContext(this.registry.get(DataType.class), reader);
+            return this.createNodeConnector(nodeId, name, dataType);
+        });
     }
 
     @Override
     public void encode(BsonWriter writer, NodeConnector<?> value, EncoderContext encoderContext) {
         Codec<UUID> uuidCodec = this.registry.get(UUID.class);
-        writer.writeStartDocument();
-        writer.writeName("nodeId");
-        encoderContext.encodeWithChildContext(uuidCodec, writer, value.nodeId());
-        writer.writeName("name");
-        writer.writeString(value.name());
-        writer.writeName("type");
-        encoderContext.encodeWithChildContext(this.registry.get(DataType.class), writer, value.type());
-        writer.writeEndDocument();
+        SerializationUtils.writeDocument(writer, () -> {
+            writer.writeName("nodeId");
+            encoderContext.encodeWithChildContext(uuidCodec, writer, value.nodeId());
+            writer.writeName("name");
+            writer.writeString(value.name());
+            writer.writeName("type");
+            encoderContext.encodeWithChildContext(this.registry.get(DataType.class), writer, value.type());
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/RegistryObjectCodec.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/RegistryObjectCodec.java
@@ -46,7 +46,7 @@ public class RegistryObjectCodec<T> implements Codec<T> {
 
         @Override
         public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
-            return Registry.REGISTRIES.getByClass(clazz).map(RegistryObjectCodec::new).orElse(null);
+            return (Codec<T>) Registry.getRegistryByClass(clazz).map(RegistryObjectCodec::new).orElse(null);
         }
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/codec/SerializationUtils.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/codec/SerializationUtils.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
@@ -96,6 +97,41 @@ public final class SerializationUtils {
             toWrite.put(keyToString.apply(entry.getKey()), entry.getValue());
         }
         context.encodeWithChildContext(parameterizedCodec, writer, toWrite);
+    }
+
+    /**
+     * Writes the start & end points of a BSON document and runs the provided runnable between them.
+     * @param writer    the BSON writer
+     * @param function  the function to run
+     */
+    public static void writeDocument(BsonWriter writer, Runnable function) {
+        writer.writeStartDocument();
+        function.run();
+        writer.writeEndDocument();
+    }
+
+    /**
+     * Reads the start & end points of a BSON document and runs the provided runnable between them.
+     * @param reader    the BSON reader
+     * @param function  the function to run
+     */
+    public static void readDocument(BsonReader reader, Runnable function) {
+        reader.readStartDocument();
+        function.run();
+        reader.readEndDocument();
+    }
+
+    /**
+     * Reads the start & end points of a BSON document and runs the provided function between them.
+     * @param reader    the BSON reader
+     * @param function  the function to run
+     * @return          the result of the function
+     */
+    public static <T> T readDocument(BsonReader reader, Supplier<T> function) {
+        reader.readStartDocument();
+        var res = function.get();
+        reader.readEndDocument();
+        return res;
     }
 
     private SerializationUtils() {}

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/Conversions.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/Conversions.java
@@ -4,8 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+//TODO automatically handle transitive conversions?
 /**
- * Manages conversions between {@link DataType DataTypes}.
+ * Manages conversions between {@link DataType DataTypes}. Conversions should only be registered in here if <strong>they will never fail</strong>.
+ * <p>For example, Number -> String is a reasonable conversion, as all numbers can be represented as strings. String -> Number is not,
+ * as not all strings are valid numbers.</p>
  */
 public final class Conversions {
     private static final Map<ConversionPair, Function<?, ?>> MAP = new HashMap<>();

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/Conversions.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/Conversions.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
 /**
  * Manages conversions between {@link DataType DataTypes}.
  */
-public final class DataTypeConversions {
+public final class Conversions {
     private static final Map<ConversionPair, Function<?, ?>> MAP = new HashMap<>();
 
     /**
@@ -57,7 +57,7 @@ public final class DataTypeConversions {
         return typeB.create(result);
     }
 
-    private DataTypeConversions() {}
+    private Conversions() {}
 
     private record ConversionPair(DataType<?> a, DataType<?> b) {
     }

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
@@ -13,7 +13,7 @@ import club.mondaylunch.gatos.core.Registry;
  */
 public sealed class DataType<T> permits ListDataType, OptionalDataType {
     public static final Registry<DataType<?>> REGISTRY = Registry.create("data_type", DataType.class);
-    public static final DataType<Integer> INTEGER = register("integer");
+    public static final DataType<Double> NUMBER = register("number");
     public static final DataType<Boolean> BOOLEAN = register("boolean");
     public static final DataType<String> STRING = register("string");
     public static final DataType<JsonObject> JSON_OBJECT = register("json_object");

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
@@ -18,6 +18,13 @@ public sealed class DataType<T> permits ListDataType, OptionalDataType {
     public static final DataType<String> STRING = register("string");
     public static final DataType<JsonObject> JSON_OBJECT = register("json_object");
     public static final DataType<DataType<?>> DATA_TYPE = register("data_type");
+    static {
+        Conversions.register(NUMBER, STRING, Object::toString);
+        Conversions.register(BOOLEAN, STRING, Object::toString);
+        Conversions.register(JSON_OBJECT, STRING, Object::toString);
+        Conversions.register(DATA_TYPE, STRING, Object::toString);
+    }
+
     private final String name;
 
     /**

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
@@ -13,6 +13,7 @@ import club.mondaylunch.gatos.core.Registry;
  */
 public sealed class DataType<T> permits ListDataType, OptionalDataType {
     public static final Registry<DataType<?>> REGISTRY = Registry.create("data_type", DataType.class);
+    public static final DataType<Object> ANY = register("any", Object.class);
     public static final DataType<Double> NUMBER = register("number", Double.class);
     public static final DataType<Boolean> BOOLEAN = register("boolean", Boolean.class);
     public static final DataType<String> STRING = register("string", String.class);
@@ -36,6 +37,7 @@ public sealed class DataType<T> permits ListDataType, OptionalDataType {
     protected DataType(String name, Class<? super T> clazz) {
         this.name = name;
         this.clazz = clazz;
+        Conversions.register(this, ANY, $ -> $);
     }
 
     public static <T> DataType<T> register(String name, Class<? super T> clazz) {

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/DataType.java
@@ -13,11 +13,11 @@ import club.mondaylunch.gatos.core.Registry;
  */
 public sealed class DataType<T> permits ListDataType, OptionalDataType {
     public static final Registry<DataType<?>> REGISTRY = Registry.create("data_type", DataType.class);
-    public static final DataType<Double> NUMBER = register("number");
-    public static final DataType<Boolean> BOOLEAN = register("boolean");
-    public static final DataType<String> STRING = register("string");
-    public static final DataType<JsonObject> JSON_OBJECT = register("json_object");
-    public static final DataType<DataType<?>> DATA_TYPE = register("data_type");
+    public static final DataType<Double> NUMBER = register("number", Double.class);
+    public static final DataType<Boolean> BOOLEAN = register("boolean", Boolean.class);
+    public static final DataType<String> STRING = register("string", String.class);
+    public static final DataType<JsonObject> JSON_OBJECT = register("json_object", JsonObject.class);
+    public static final DataType<DataType<?>> DATA_TYPE = register("data_type", DataType.class);
     static {
         Conversions.register(NUMBER, STRING, Object::toString);
         Conversions.register(BOOLEAN, STRING, Object::toString);
@@ -26,16 +26,20 @@ public sealed class DataType<T> permits ListDataType, OptionalDataType {
     }
 
     private final String name;
+    private final Class<? super T> clazz;
 
     /**
-     * @param name the name for the type this represents
+     * Creates a new DataType.
+     * @param name  the name for the type this represents
+     * @param clazz the class for this type
      */
-    protected DataType(String name) {
+    protected DataType(String name, Class<? super T> clazz) {
         this.name = name;
+        this.clazz = clazz;
     }
 
-    public static <T> DataType<T> register(String name) {
-        return REGISTRY.register(name, new DataType<>(name));
+    public static <T> DataType<T> register(String name, Class<? super T> clazz) {
+        return REGISTRY.register(name, new DataType<>(name, clazz));
     }
 
     /**
@@ -49,10 +53,18 @@ public sealed class DataType<T> permits ListDataType, OptionalDataType {
 
     /**
      * The unique name of this data type.
-     * @return the unique name of this data type.
+     * @return the unique name of this data type
      */
     public String name() {
         return this.name;
+    }
+
+    /**
+     * The class of this data type.
+     * @return  the class of this data type
+     */
+    public Class<? super T> clazz() {
+        return this.clazz;
     }
 
     /**

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/DataTypeConversions.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/DataTypeConversions.java
@@ -29,7 +29,7 @@ public final class DataTypeConversions {
      * @return  whether there is a conversion between the two
      */
     public static boolean canConvert(DataType<?> a, DataType<?> b) {
-        return MAP.containsKey(new ConversionPair(a, b));
+        return a.equals(b) || MAP.containsKey(new ConversionPair(a, b));
     }
 
     /**
@@ -40,8 +40,11 @@ public final class DataTypeConversions {
      * @param <B>       the second type
      * @return          the converted DataBox
      */
+    @SuppressWarnings("unchecked")
     public static <A, B> DataBox<B> convert(DataBox<A> a, DataType<B> typeB) {
-        @SuppressWarnings("unchecked")
+        if (a.type().equals(typeB)) {
+            return (DataBox<B>) a;
+        }
         var func = (Function<A, B>) MAP.get(new ConversionPair(a.type(), typeB));
         if (func == null) {
             throw new ConversionException("Cannot convert %s to %s".formatted(a.type(), typeB));

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/DataTypeConversions.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/DataTypeConversions.java
@@ -1,0 +1,78 @@
+package club.mondaylunch.gatos.core.data;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Manages conversions between {@link DataType DataTypes}.
+ */
+public final class DataTypeConversions {
+    private static final Map<ConversionPair, Function<?, ?>> MAP = new HashMap<>();
+
+    /**
+     * Register a conversion between two types.
+     * @param typeA                 the first DataType
+     * @param typeB                 the second DataType
+     * @param conversionFunction    a function to convert from A to B
+     * @param <A>                   the first type
+     * @param <B>                   the second type
+     */
+    public static <A, B> void register(DataType<A> typeA, DataType<B> typeB, Function<A, B> conversionFunction) {
+        MAP.put(new ConversionPair(typeA, typeB), conversionFunction);
+    }
+
+    /**
+     * Determines whether there is a conversion registered between two DataTypes.
+     * @param a the first DataType
+     * @param b the second DataType
+     * @return  whether there is a conversion between the two
+     */
+    public static boolean canConvert(DataType<?> a, DataType<?> b) {
+        return MAP.containsKey(new ConversionPair(a, b));
+    }
+
+    /**
+     * Convert a DataBox of one type to another.
+     * @param a         the DataBox to convert
+     * @param typeB     the DataType to convert to
+     * @param <A>       the first type
+     * @param <B>       the second type
+     * @return          the converted DataBox
+     */
+    public static <A, B> DataBox<B> convert(DataBox<A> a, DataType<B> typeB) {
+        @SuppressWarnings("unchecked")
+        var func = (Function<A, B>) MAP.get(new ConversionPair(a.type(), typeB));
+        if (func == null) {
+            throw new ConversionException("Cannot convert %s to %s".formatted(a.type(), typeB));
+        }
+        B result = func.apply(a.value());
+        if (result == null) {
+            throw new ConversionException("Conversion function %s -> %s on %s returned null!".formatted(a.type(), typeB, a.value()));
+        }
+
+        return typeB.create(result);
+    }
+
+    private DataTypeConversions() {}
+
+    private record ConversionPair(DataType<?> a, DataType<?> b) {
+    }
+
+    /**
+     * Thrown when there is an error in DataType conversion.
+     */
+    public static class ConversionException extends RuntimeException {
+        public ConversionException(String message) {
+            super(message);
+        }
+
+        public ConversionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public ConversionException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
@@ -16,7 +16,7 @@ public final class ListDataType<T> extends DataType<List<T>> {
     }
 
     /**
-     * Creates the name for the list type that holds a given type
+     * Creates the name for the list type that holds a given type.
      * @param type  the type
      * @return      the name of a list type for the type
      */
@@ -25,7 +25,7 @@ public final class ListDataType<T> extends DataType<List<T>> {
     }
 
     /**
-     * Gets the datatype this datatype is specialised for
+     * Gets the datatype this datatype is specialised for.
      * @return the datatype held by lists of this type
      */
     public DataType<T> contains() {

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
@@ -3,14 +3,14 @@ package club.mondaylunch.gatos.core.data;
 import java.util.List;
 
 public final class ListDataType<T> extends DataType<List<T>> {
-    public static final DataType<List<?>> GENERIC_LIST = DataType.register("list");
+    public static final DataType<List<?>> GENERIC_LIST = DataType.register("list", List.class);
     private final DataType<T> contains;
 
     /**
      * @param contains the datatype that this list will contain
      */
     public ListDataType(DataType<T> contains) {
-        super(makeName(contains));
+        super(makeName(contains), List.class);
         this.contains = contains;
         Conversions.register(this, GENERIC_LIST, $ -> $);
     }

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
@@ -3,6 +3,7 @@ package club.mondaylunch.gatos.core.data;
 import java.util.List;
 
 public final class ListDataType<T> extends DataType<List<T>> {
+    public static final DataType<List<?>> GENERIC_LIST = DataType.register("list");
     private final DataType<T> contains;
 
     /**
@@ -11,6 +12,7 @@ public final class ListDataType<T> extends DataType<List<T>> {
     public ListDataType(DataType<T> contains) {
         super(makeName(contains));
         this.contains = contains;
+        Conversions.register(this, GENERIC_LIST, $ -> $);
     }
 
     /**

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/ListDataType.java
@@ -1,0 +1,32 @@
+package club.mondaylunch.gatos.core.data;
+
+import java.util.List;
+
+public final class ListDataType<T> extends DataType<List<T>> {
+    private final DataType<T> contains;
+
+    /**
+     * @param contains the datatype that this list will contain
+     */
+    public ListDataType(DataType<T> contains) {
+        super(makeName(contains));
+        this.contains = contains;
+    }
+
+    /**
+     * Creates the name for the list type that holds a given type
+     * @param type  the type
+     * @return      the name of a list type for the type
+     */
+    public static String makeName(DataType<?> type) {
+        return "list$"+type.name();
+    }
+
+    /**
+     * Gets the datatype this datatype is specialised for
+     * @return the datatype held by lists of this type
+     */
+    public DataType<T> contains() {
+        return this.contains;
+    }
+}

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
@@ -1,17 +1,16 @@
 package club.mondaylunch.gatos.core.data;
 
-import java.util.List;
 import java.util.Optional;
 
 public final class OptionalDataType<T> extends DataType<Optional<T>> {
-    public static final DataType<Optional<?>> GENERIC_OPTIONAL = DataType.register("optional");
+    public static final DataType<Optional<?>> GENERIC_OPTIONAL = DataType.register("optional", Optional.class);
     private final DataType<T> contains;
 
     /**
      * @param contains the datatype that this optional will contain
      */
     public OptionalDataType(DataType<T> contains) {
-        super(makeName(contains));
+        super(makeName(contains), Optional.class);
         this.contains = contains;
         Conversions.register(this, GENERIC_OPTIONAL, $ -> $);
     }

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
@@ -1,0 +1,32 @@
+package club.mondaylunch.gatos.core.data;
+
+import java.util.Optional;
+
+public final class OptionalDataType<T> extends DataType<Optional<T>> {
+    private final DataType<T> contains;
+
+    /**
+     * @param contains the datatype that this optional will contain
+     */
+    public OptionalDataType(DataType<T> contains) {
+        super(makeName(contains));
+        this.contains = contains;
+    }
+
+    /**
+     * Creates the name for the optional type that holds a given type
+     * @param type  the type
+     * @return      the name of an optional type for the type
+     */
+    public static String makeName(DataType<?> type) {
+        return "optional$"+type.name();
+    }
+
+    /**
+     * Gets the datatype this datatype is specialised for
+     * @return the datatype held by optionals of this type
+     */
+    public DataType<T> contains() {
+        return this.contains;
+    }
+}

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
@@ -16,7 +16,7 @@ public final class OptionalDataType<T> extends DataType<Optional<T>> {
     }
 
     /**
-     * Creates the name for the optional type that holds a given type
+     * Creates the name for the optional type that holds a given type.
      * @param type  the type
      * @return      the name of an optional type for the type
      */
@@ -25,7 +25,7 @@ public final class OptionalDataType<T> extends DataType<Optional<T>> {
     }
 
     /**
-     * Gets the datatype this datatype is specialised for
+     * Gets the datatype this datatype is specialised for.
      * @return the datatype held by optionals of this type
      */
     public DataType<T> contains() {

--- a/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/data/OptionalDataType.java
@@ -1,8 +1,10 @@
 package club.mondaylunch.gatos.core.data;
 
+import java.util.List;
 import java.util.Optional;
 
 public final class OptionalDataType<T> extends DataType<Optional<T>> {
+    public static final DataType<Optional<?>> GENERIC_OPTIONAL = DataType.register("optional");
     private final DataType<T> contains;
 
     /**
@@ -11,6 +13,7 @@ public final class OptionalDataType<T> extends DataType<Optional<T>> {
     public OptionalDataType(DataType<T> contains) {
         super(makeName(contains));
         this.contains = contains;
+        Conversions.register(this, GENERIC_OPTIONAL, $ -> $);
     }
 
     /**

--- a/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
@@ -10,13 +10,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import club.mondaylunch.gatos.core.data.DataBox;
+import org.jetbrains.annotations.Unmodifiable;
+
 import club.mondaylunch.gatos.core.data.Conversions;
+import club.mondaylunch.gatos.core.data.DataBox;
 import club.mondaylunch.gatos.core.graph.Node;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
 import club.mondaylunch.gatos.core.graph.type.NodeCategory;
 import club.mondaylunch.gatos.core.graph.type.NodeType;
-import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * Handles execution of a {@link club.mondaylunch.gatos.core.graph.Graph flow

--- a/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
@@ -10,13 +10,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.jetbrains.annotations.Unmodifiable;
-
 import club.mondaylunch.gatos.core.data.DataBox;
+import club.mondaylunch.gatos.core.data.DataTypeConversions;
 import club.mondaylunch.gatos.core.graph.Node;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
 import club.mondaylunch.gatos.core.graph.type.NodeCategory;
 import club.mondaylunch.gatos.core.graph.type.NodeType;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * Handles execution of a {@link club.mondaylunch.gatos.core.graph.Graph flow
@@ -80,7 +80,7 @@ public class GraphExecutor {
         for (var dep : this.nodeDependencies.get(node)) {
             var resForDep = allResults.get(dep);
             var depInputName = dep.to().name();
-            inputs.put(depInputName, resForDep.join());
+            inputs.put(depInputName, DataTypeConversions.convert(resForDep.join(), dep.to().type()));
         }
 
         return inputs;
@@ -118,7 +118,7 @@ public class GraphExecutor {
      */
     private Iterable<NodeConnection<?>> getOutputConnectionsByName(Node node, String name) {
         return node.getOutputWithName(name).stream()
-                .flatMap(c -> this.connections.stream().filter(a -> a.from().equals(c)))
+                .flatMap(c -> this.connections.stream().filter(a -> a.from().isCompatible(c)))
                 .toList();
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import club.mondaylunch.gatos.core.data.DataBox;
-import club.mondaylunch.gatos.core.data.DataTypeConversions;
+import club.mondaylunch.gatos.core.data.Conversions;
 import club.mondaylunch.gatos.core.graph.Node;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
 import club.mondaylunch.gatos.core.graph.type.NodeCategory;
@@ -80,7 +80,7 @@ public class GraphExecutor {
         for (var dep : this.nodeDependencies.get(node)) {
             var resForDep = allResults.get(dep);
             var depInputName = dep.to().name();
-            inputs.put(depInputName, DataTypeConversions.convert(resForDep.join(), dep.to().type()));
+            inputs.put(depInputName, Conversions.convert(resForDep.join(), dep.to().type()));
         }
 
         return inputs;

--- a/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/executor/GraphExecutor.java
@@ -118,7 +118,7 @@ public class GraphExecutor {
      */
     private Iterable<NodeConnection<?>> getOutputConnectionsByName(Node node, String name) {
         return node.getOutputWithName(name).stream()
-                .flatMap(c -> this.connections.stream().filter(a -> a.from().isCompatible(c)))
+                .flatMap(c -> this.connections.stream().filter(a -> c.isCompatible(a.from())))
                 .toList();
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
@@ -14,10 +14,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
 
-import club.mondaylunch.gatos.core.codec.SerializationUtils;
-import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
-import club.mondaylunch.gatos.core.graph.type.NodeCategory;
-import club.mondaylunch.gatos.core.graph.type.NodeType;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 import org.bson.codecs.Codec;
@@ -25,6 +21,11 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.jetbrains.annotations.Nullable;
+
+import club.mondaylunch.gatos.core.codec.SerializationUtils;
+import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
+import club.mondaylunch.gatos.core.graph.type.NodeCategory;
+import club.mondaylunch.gatos.core.graph.type.NodeType;
 
 /**
  * A flow graph.

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
@@ -14,6 +14,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
 
+import club.mondaylunch.gatos.core.codec.SerializationUtils;
+import club.mondaylunch.gatos.core.data.DataTypeConversions;
+import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
+import club.mondaylunch.gatos.core.graph.type.NodeCategory;
+import club.mondaylunch.gatos.core.graph.type.NodeType;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 import org.bson.codecs.Codec;
@@ -21,11 +26,6 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.jetbrains.annotations.Nullable;
-
-import club.mondaylunch.gatos.core.codec.SerializationUtils;
-import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
-import club.mondaylunch.gatos.core.graph.type.NodeCategory;
-import club.mondaylunch.gatos.core.graph.type.NodeType;
 
 /**
  * A flow graph.
@@ -331,11 +331,13 @@ public class Graph {
      */
     private static boolean isConnectionValid(Node node, NodeConnection<?> connection) {
         if (connection.from().nodeId().equals(node.id())) {
-            return node.getOutputs().containsValue(connection.from());
+            return node.getOutputWithName(connection.from().name()).map(it ->
+                it.isCompatible(connection.from())
+            ).orElse(false);
         }
 
         if (connection.to().nodeId().equals(node.id())) {
-            return node.inputs().containsValue(connection.to());
+            return node.getInputWithName(connection.to().name()).map(connection.to()::equals).orElse(false);
         }
 
         return false;

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 import java.util.function.UnaryOperator;
 
 import club.mondaylunch.gatos.core.codec.SerializationUtils;
-import club.mondaylunch.gatos.core.data.DataTypeConversions;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
 import club.mondaylunch.gatos.core.graph.type.NodeCategory;
 import club.mondaylunch.gatos.core.graph.type.NodeType;

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnection.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnection.java
@@ -3,7 +3,7 @@ package club.mondaylunch.gatos.core.graph.connector;
 import java.util.Optional;
 
 import club.mondaylunch.gatos.core.data.DataType;
-import club.mondaylunch.gatos.core.data.DataTypeConversions;
+import club.mondaylunch.gatos.core.data.Conversions;
 import club.mondaylunch.gatos.core.graph.Node;
 
 /**
@@ -27,7 +27,7 @@ public record NodeConnection<T>(
 
         var from = fromOpt.get();
         var to = toOpt.get();
-        if (!DataTypeConversions.canConvert(from.type(), to.type()) || !to.type().equals(type)) {
+        if (!Conversions.canConvert(from.type(), to.type()) || !to.type().equals(type)) {
             return Optional.empty();
         }
 

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnection.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnection.java
@@ -3,6 +3,7 @@ package club.mondaylunch.gatos.core.graph.connector;
 import java.util.Optional;
 
 import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.DataTypeConversions;
 import club.mondaylunch.gatos.core.graph.Node;
 
 /**
@@ -26,13 +27,13 @@ public record NodeConnection<T>(
 
         var from = fromOpt.get();
         var to = toOpt.get();
-        if (!from.type().equals(to.type()) || !from.type().equals(type)) {
+        if (!DataTypeConversions.canConvert(from.type(), to.type()) || !to.type().equals(type)) {
             return Optional.empty();
         }
 
         // We know this cast succeeds because of the check above
         // noinspection unchecked
-        var conn = new NodeConnection<T>((NodeConnector.Output<T>) from, (NodeConnector.Input<T>) to);
+        var conn = new NodeConnection<T>(from.withType(type), (NodeConnector.Input<T>) to);
         return Optional.of(conn);
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnector.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnector.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import club.mondaylunch.gatos.core.data.DataType;
-import club.mondaylunch.gatos.core.data.DataTypeConversions;
+import club.mondaylunch.gatos.core.data.Conversions;
 
 /**
  * Represents an input or output on a node.
@@ -104,7 +104,7 @@ public abstract sealed class NodeConnector<T> {
         public boolean isCompatible(Output<?> other) {
             return this.nodeId().equals(other.nodeId())
                 && this.name().equals(other.name())
-                && DataTypeConversions.canConvert(this.type(), other.type());
+                && Conversions.canConvert(this.type(), other.type());
         }
     }
 }

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnector.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/connector/NodeConnector.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.DataTypeConversions;
 
 /**
  * Represents an input or output on a node.
@@ -82,6 +83,28 @@ public abstract sealed class NodeConnector<T> {
     public static final class Output<T> extends NodeConnector<T> {
         public Output(UUID nodeId, String name, DataType<T> dataType) {
             super(nodeId, name, dataType);
+        }
+
+        /**
+         * Returns a new object which refers to the same connector conceptually, but with a different datatype.
+         * @param type  the new datatype
+         * @param <B>   the new type
+         * @return      a new output connector with the type
+         */
+        public <B> Output<B> withType(DataType<B> type) {
+            return new Output<>(this.nodeId(), this.name(), type);
+        }
+
+        /**
+         * Returns whether the other connector has the same node ID and name, and that this connector's datatype can be
+         * converted to the other connector's.
+         * @param other the other connector
+         * @return      whether the connectors are compatible
+         */
+        public boolean isCompatible(Output<?> other) {
+            return this.nodeId().equals(other.nodeId())
+                && this.name().equals(other.name())
+                && DataTypeConversions.canConvert(this.type(), other.type());
         }
     }
 }

--- a/core/src/test/java/club/mondaylunch/gatos/core/RegistryTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/RegistryTest.java
@@ -18,7 +18,7 @@ public class RegistryTest {
     @Test
     public void testRegistryProperlyCreated() {
         Assertions.assertEquals(Foo.class, FOO_REGISTRY.getClazz());
-        Assertions.assertEquals(FOO_REGISTRY, Registry.REGISTRIES.getByClass(Foo.class).orElseThrow());
+        Assertions.assertEquals(FOO_REGISTRY, Registry.getRegistryByClass(Foo.class).orElseThrow());
         Assertions.assertEquals(FOO_REGISTRY, Registry.REGISTRIES.get("foo").orElseThrow());
         Assertions.assertEquals("foo", Registry.REGISTRIES.getName(FOO_REGISTRY).orElse(null));
     }

--- a/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataBoxCodecTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataBoxCodecTest.java
@@ -1,0 +1,148 @@
+package club.mondaylunch.gatos.core.codec.test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import club.mondaylunch.gatos.core.Database;
+import club.mondaylunch.gatos.core.codec.ClassModelRegistry;
+import club.mondaylunch.gatos.core.collection.BaseCollection;
+import club.mondaylunch.gatos.core.data.DataBox;
+import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.models.BaseModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DataBoxCodecTest {
+
+    static {
+        ClassModelRegistry.register(
+            DataBoxContainer.class,
+            DataBoxContainerContainer.class
+        );
+        Database.refreshCodecRegistry();
+    }
+
+    private static final BaseCollection<DataBoxContainer> CONTAINER_COLLECTION = new BaseCollection<>("dataBoxContainers", DataBoxContainer.class);
+    private static final BaseCollection<DataBoxContainerContainer> CONTAINER_CONTAINER_COLLECTION = new BaseCollection<>("dataBoxContainerContainers", DataBoxContainerContainer.class);
+
+    @BeforeEach
+    void setUp() {
+        this.reset();
+        assertContainerCount(0);
+        assertContainerContainerCount(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.reset();
+    }
+
+    private void reset() {
+        CONTAINER_COLLECTION.clear();
+        CONTAINER_CONTAINER_COLLECTION.clear();
+    }
+
+    @Test
+    public void canInsertDataBoxContainer() {
+        assertInsertDataBoxContainers(DataType.NUMBER.create(1.0));
+    }
+
+    @Test
+    public void canInsertMultipleDataBoxContainers() {
+        assertInsertDataBoxContainers(
+            DataType.NUMBER.create(10.0),
+            DataType.BOOLEAN.create(false),
+            DataType.STRING.create("fhg;ksghuierhdkfglds"),
+            DataType.BOOLEAN.optionalOf().create(Optional.empty()),
+            DataType.BOOLEAN.optionalOf().create(Optional.of(true)),
+            DataType.STRING.listOf().create(List.of("foo","fhqwghads", "bar")),
+            DataType.STRING.listOf().create(List.of())
+        );
+    }
+
+    @Test
+    public void canInsertDataBoxContainersWithDuplicates() {
+        assertInsertDataBoxContainers(
+            DataType.NUMBER.create(10.0),
+            DataType.BOOLEAN.create(false),
+            DataType.BOOLEAN.create(false),
+            DataType.BOOLEAN.create(false),
+            DataType.NUMBER.create(10.0)
+        );
+    }
+
+    @Test
+    public void canInsertNestedContainer() {
+        UUID id = UUID.randomUUID();
+        DataBox<?> dataBox = DataType.NUMBER.create(5.0);
+        DataBoxContainer container = new DataBoxContainer(UUID.randomUUID(), dataBox);
+        DataBoxContainerContainer containerContainer = new DataBoxContainerContainer(id, container);
+        CONTAINER_CONTAINER_COLLECTION.insert(containerContainer);
+        assertContainerContainerCount(1);
+        DataBoxContainerContainer retrievedContainerContainer = CONTAINER_CONTAINER_COLLECTION.get(id);
+        Assertions.assertNotNull(retrievedContainerContainer);
+        DataBoxContainer retrievedContainer = retrievedContainerContainer.dataBoxContainer;
+        Assertions.assertNotNull(retrievedContainer);
+        Assertions.assertSame(dataBox, retrievedContainer.dataBox);
+    }
+
+    private static UUID insertDataBoxContainer(DataBox<?> dataBox) {
+        UUID id = UUID.randomUUID();
+        DataBoxContainer container = new DataBoxContainer(id, dataBox);
+        long countBefore = CONTAINER_COLLECTION.size();
+        CONTAINER_COLLECTION.insert(container);
+        assertContainerCount(countBefore + 1);
+        return id;
+    }
+
+    private static void assertInsertDataBoxContainers(DataBox<?>... dataBoxs) {
+        int inserted = 0;
+        for (DataBox<?> dataBox : dataBoxs) {
+            UUID id = insertDataBoxContainer(dataBox);
+            inserted++;
+            assertContainerCount(inserted);
+            DataBoxContainer retrievedContainer = CONTAINER_COLLECTION.get(id);
+            Assertions.assertNotNull(retrievedContainer);
+            Assertions.assertSame(dataBox, retrievedContainer.dataBox);
+        }
+    }
+
+    private static void assertContainerCount(long expected) {
+        Assertions.assertEquals(expected, CONTAINER_COLLECTION.size());
+    }
+
+    private static void assertContainerContainerCount(long expected) {
+        Assertions.assertEquals(expected, CONTAINER_CONTAINER_COLLECTION.size());
+    }
+
+    public static class DataBoxContainer extends BaseModel {
+
+        public DataBox<?> dataBox;
+
+        public DataBoxContainer(UUID id, DataBox<?> dataBox) {
+            super(id);
+            this.dataBox = dataBox;
+        }
+
+        @SuppressWarnings("unused")
+        public DataBoxContainer() {
+        }
+    }
+
+    public static class DataBoxContainerContainer extends BaseModel {
+
+        public DataBoxContainer dataBoxContainer;
+
+        public DataBoxContainerContainer(UUID id, DataBoxContainer dataBoxContainer) {
+            super(id);
+            this.dataBoxContainer = dataBoxContainer;
+        }
+
+        @SuppressWarnings("unused")
+        public DataBoxContainerContainer() {
+        }
+    }
+}

--- a/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataBoxCodecTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataBoxCodecTest.java
@@ -4,16 +4,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import club.mondaylunch.gatos.core.Database;
 import club.mondaylunch.gatos.core.codec.ClassModelRegistry;
 import club.mondaylunch.gatos.core.collection.BaseCollection;
 import club.mondaylunch.gatos.core.data.DataBox;
 import club.mondaylunch.gatos.core.data.DataType;
 import club.mondaylunch.gatos.core.models.BaseModel;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class DataBoxCodecTest {
 
@@ -58,7 +59,7 @@ public class DataBoxCodecTest {
             DataType.STRING.create("fhg;ksghuierhdkfglds"),
             DataType.BOOLEAN.optionalOf().create(Optional.empty()),
             DataType.BOOLEAN.optionalOf().create(Optional.of(true)),
-            DataType.STRING.listOf().create(List.of("foo","fhqwghads", "bar")),
+            DataType.STRING.listOf().create(List.of("foo", "fhqwghads", "bar")),
             DataType.STRING.listOf().create(List.of())
         );
     }

--- a/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataBoxCodecTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataBoxCodecTest.java
@@ -87,7 +87,7 @@ public class DataBoxCodecTest {
         Assertions.assertNotNull(retrievedContainerContainer);
         DataBoxContainer retrievedContainer = retrievedContainerContainer.dataBoxContainer;
         Assertions.assertNotNull(retrievedContainer);
-        Assertions.assertSame(dataBox, retrievedContainer.dataBox);
+        Assertions.assertEquals(dataBox, retrievedContainer.dataBox);
     }
 
     private static UUID insertDataBoxContainer(DataBox<?> dataBox) {
@@ -107,7 +107,7 @@ public class DataBoxCodecTest {
             assertContainerCount(inserted);
             DataBoxContainer retrievedContainer = CONTAINER_COLLECTION.get(id);
             Assertions.assertNotNull(retrievedContainer);
-            Assertions.assertSame(dataBox, retrievedContainer.dataBox);
+            Assertions.assertEquals(dataBox, retrievedContainer.dataBox);
         }
     }
 

--- a/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataTypeCodecTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/codec/test/DataTypeCodecTest.java
@@ -45,13 +45,13 @@ public class DataTypeCodecTest {
 
     @Test
     public void canInsertDataTypeContainer() {
-        assertInsertDataTypeContainers(DataType.INTEGER);
+        assertInsertDataTypeContainers(DataType.NUMBER);
     }
 
     @Test
     public void canInsertMultipleDataTypeContainers() {
         assertInsertDataTypeContainers(
-            DataType.INTEGER,
+            DataType.NUMBER,
             DataType.BOOLEAN,
             DataType.STRING
         );
@@ -60,10 +60,10 @@ public class DataTypeCodecTest {
     @Test
     public void canInsertDataTypeContainersWithDuplicates() {
         assertInsertDataTypeContainers(
-            DataType.INTEGER,
+            DataType.NUMBER,
             DataType.BOOLEAN,
             DataType.STRING,
-            DataType.INTEGER,
+            DataType.NUMBER,
             DataType.BOOLEAN,
             DataType.STRING
         );
@@ -72,7 +72,7 @@ public class DataTypeCodecTest {
     @Test
     public void canInsertNestedContainer() {
         UUID id = UUID.randomUUID();
-        DataType<?> dataType = DataType.INTEGER;
+        DataType<?> dataType = DataType.NUMBER;
         DataTypeContainer container = new DataTypeContainer(UUID.randomUUID(), dataType);
         DataTypeContainerContainer containerContainer = new DataTypeContainerContainer(id, container);
         CONTAINER_CONTAINER_COLLECTION.insert(containerContainer);

--- a/core/src/test/java/club/mondaylunch/gatos/core/collection/test/GraphSerializationTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/collection/test/GraphSerializationTest.java
@@ -76,8 +76,8 @@ public class GraphSerializationTest {
         Node node1 = graph.addNode(TestNodeTypes.START);
         Node node2 = graph.addNode(TestNodeTypes.PROCESS);
         Node node3 = graph.addNode(TestNodeTypes.END);
-        var connection1 = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
-        var connection2 = NodeConnection.createConnection(node2, "out", node3, "in", DataType.INTEGER);
+        var connection1 = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
+        var connection2 = NodeConnection.createConnection(node2, "out", node3, "in", DataType.NUMBER);
         graph.addConnection(connection1.orElseThrow());
         graph.addConnection(connection2.orElseThrow());
         Flow.objects.insert(flow);

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ConversionsTest {
-    private static final DataType<Foo> FOO_TYPE = DataType.register("foo");
-    private static final DataType<Bar> BAR_TYPE = DataType.register("bar");
-    private static final DataType<Baz> BAZ_TYPE = DataType.register("baz");
+    private static final DataType<Foo> FOO_TYPE = DataType.register("foo", Foo.class);
+    private static final DataType<Bar> BAR_TYPE = DataType.register("bar", Bar.class);
+    private static final DataType<Baz> BAZ_TYPE = DataType.register("baz", Baz.class);
 
     @Test
     public void canRegisterConversion() {

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
@@ -1,0 +1,63 @@
+package club.mondaylunch.gatos.core.data.test;
+
+import club.mondaylunch.gatos.core.data.Conversions;
+import club.mondaylunch.gatos.core.data.DataType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConversionsTest {
+    private static final DataType<Foo> FOO_TYPE = DataType.register("foo");
+    private static final DataType<Bar> BAR_TYPE = DataType.register("bar");
+    private static final DataType<Baz> BAZ_TYPE = DataType.register("baz");
+
+    @Test
+    public void canRegisterConversion() {
+        Assertions.assertDoesNotThrow(() -> {
+            Conversions.register(FOO_TYPE, BAR_TYPE, foo -> new Bar(foo.name()));
+        });
+    }
+
+    @Test
+    public void canConvertIsCorrect() {
+        Conversions.register(FOO_TYPE, BAR_TYPE, foo -> new Bar(foo.name()));
+        Assertions.assertTrue(Conversions.canConvert(FOO_TYPE, BAR_TYPE));
+        Assertions.assertFalse(Conversions.canConvert(BAR_TYPE, FOO_TYPE));
+    }
+
+    @Test
+    public void canConvertToSelf() {
+        Assertions.assertTrue(Conversions.canConvert(FOO_TYPE, FOO_TYPE));
+        var foo = FOO_TYPE.create(new Foo("hello!"));
+        Assertions.assertEquals(foo, Conversions.convert(foo, FOO_TYPE));
+    }
+
+    @Test
+    public void testConversion() {
+        Conversions.register(FOO_TYPE, BAR_TYPE, foo -> new Bar(foo.name()));
+        var foo = FOO_TYPE.create(new Foo("hello!"));
+        var bar = BAR_TYPE.create(new Bar("hello!"));
+        Assertions.assertEquals(bar, Conversions.convert(foo, BAR_TYPE));
+    }
+
+    @Test
+    public void incorrectConversionFails() {
+        Conversions.register(FOO_TYPE, BAR_TYPE, foo -> new Bar(foo.name()));
+        var bar = BAR_TYPE.create(new Bar("hello!"));
+        Assertions.assertThrows(Conversions.ConversionException.class, () -> {
+            Conversions.convert(bar, FOO_TYPE);
+        });
+    }
+
+    @Test
+    public void nullConversionFails() {
+        Conversions.register(FOO_TYPE, BAZ_TYPE, foo -> null);
+        var foo = FOO_TYPE.create(new Foo("hello!"));
+        Assertions.assertThrows(Conversions.ConversionException.class, () -> {
+            Conversions.convert(foo, BAZ_TYPE);
+        });
+    }
+
+    private record Foo(String name) {}
+    private record Bar(String name) {}
+    private record Baz(String name) {}
+}

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
@@ -1,9 +1,10 @@
 package club.mondaylunch.gatos.core.data.test;
 
-import club.mondaylunch.gatos.core.data.Conversions;
-import club.mondaylunch.gatos.core.data.DataType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import club.mondaylunch.gatos.core.data.Conversions;
+import club.mondaylunch.gatos.core.data.DataType;
 
 public class ConversionsTest {
     private static final DataType<Foo> FOO_TYPE = DataType.register("foo", Foo.class);

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/ConversionsTest.java
@@ -1,10 +1,15 @@
 package club.mondaylunch.gatos.core.data.test;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import club.mondaylunch.gatos.core.data.Conversions;
 import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.ListDataType;
+import club.mondaylunch.gatos.core.data.OptionalDataType;
 
 public class ConversionsTest {
     private static final DataType<Foo> FOO_TYPE = DataType.register("foo", Foo.class);
@@ -55,6 +60,32 @@ public class ConversionsTest {
         var foo = FOO_TYPE.create(new Foo("hello!"));
         Assertions.assertThrows(Conversions.ConversionException.class, () -> {
             Conversions.convert(foo, BAZ_TYPE);
+        });
+    }
+
+    @Test
+    public void canConvertListType() {
+        var list = List.of(new Foo("hello!"));
+        var fooList = FOO_TYPE.listOf().create(list);
+        Assertions.assertDoesNotThrow(() -> {
+            Conversions.convert(fooList, ListDataType.GENERIC_LIST);
+        });
+    }
+
+    @Test
+    public void canConvertOptionalType() {
+        var opt = Optional.of(new Foo("hello!"));
+        var fooOpt = FOO_TYPE.optionalOf().create(opt);
+        Assertions.assertDoesNotThrow(() -> {
+            Conversions.convert(fooOpt, OptionalDataType.GENERIC_OPTIONAL);
+        });
+    }
+
+    @Test
+    public void canConvertToAny() {
+        var foo = FOO_TYPE.create(new Foo("Hello!"));
+        Assertions.assertDoesNotThrow(() -> {
+            Conversions.convert(foo, DataType.ANY);
         });
     }
 

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/DataBoxTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/DataBoxTest.java
@@ -12,14 +12,14 @@ import club.mondaylunch.gatos.core.data.DataType;
 public class DataBoxTest {
     @Test
     public void canCreateDataBox() {
-        var box = DataType.INTEGER.create(5);
+        var box = DataType.NUMBER.create(5.);
         Assertions.assertEquals(5, box.value());
     }
 
     @Test
     public void canMakeNewBoxWithValue() {
-        var box = DataType.INTEGER.create(5);
-        var newBox = box.withValue(10);
+        var box = DataType.NUMBER.create(5.);
+        var newBox = box.withValue(10.);
         Assertions.assertEquals(10, newBox.value());
         Assertions.assertEquals(5, box.value());
     }
@@ -27,9 +27,9 @@ public class DataBoxTest {
     @Test
     public void canGetValueFromMap() {
         Map<String, DataBox<?>> boxes = new HashMap<>();
-        boxes.put("my_int", DataType.INTEGER.create(10));
+        boxes.put("my_num", DataType.NUMBER.create(10.));
 
-        var box = DataBox.get(boxes, "my_int", DataType.INTEGER);
+        var box = DataBox.get(boxes, "my_num", DataType.NUMBER);
         Assertions.assertTrue(box.isPresent());
         Assertions.assertEquals(10, box.get());
     }
@@ -38,7 +38,7 @@ public class DataBoxTest {
     public void missingValueFromMapGivesEmpty() {
         Map<String, DataBox<?>> boxes = new HashMap<>();
 
-        var box = DataBox.get(boxes, "my_int", DataType.INTEGER);
+        var box = DataBox.get(boxes, "my_num", DataType.NUMBER);
         Assertions.assertFalse(box.isPresent());
     }
 
@@ -47,7 +47,7 @@ public class DataBoxTest {
         Map<String, DataBox<?>> boxes = new HashMap<>();
         boxes.put("my_int", DataType.BOOLEAN.create(false)); // lies!!!
 
-        var box = DataBox.get(boxes, "my_int", DataType.INTEGER);
+        var box = DataBox.get(boxes, "my_num", DataType.NUMBER);
         Assertions.assertFalse(box.isPresent());
     }
 }

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/DataTypeTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/DataTypeTest.java
@@ -1,10 +1,11 @@
 package club.mondaylunch.gatos.core.data.test;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import club.mondaylunch.gatos.core.data.DataType;
 import club.mondaylunch.gatos.core.data.ListDataType;
 import club.mondaylunch.gatos.core.data.OptionalDataType;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class DataTypeTest {
     @Test

--- a/core/src/test/java/club/mondaylunch/gatos/core/data/test/DataTypeTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/data/test/DataTypeTest.java
@@ -1,0 +1,27 @@
+package club.mondaylunch.gatos.core.data.test;
+
+import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.ListDataType;
+import club.mondaylunch.gatos.core.data.OptionalDataType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DataTypeTest {
+    @Test
+    public void canUseListType() {
+        var type = DataType.NUMBER;
+        var listType = type.listOf();
+        Assertions.assertInstanceOf(ListDataType.class, listType);
+        Assertions.assertEquals(type, ((ListDataType<Double>) listType).contains());
+        Assertions.assertEquals(listType, type.listOf());
+    }
+
+    @Test
+    public void canUseOptionalType() {
+        var type = DataType.NUMBER;
+        var optionalOf = type.optionalOf();
+        Assertions.assertInstanceOf(OptionalDataType.class, optionalOf);
+        Assertions.assertEquals(type, ((OptionalDataType<Double>) optionalOf).contains());
+        Assertions.assertEquals(optionalOf, type.optionalOf());
+    }
+}

--- a/core/src/test/java/club/mondaylunch/gatos/core/executor/test/GraphExecutorTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/executor/test/GraphExecutorTest.java
@@ -231,7 +231,7 @@ public class GraphExecutorTest {
 
         CompletableFuture.runAsync(graphExecutor.execute()).join();
         Assertions.assertEquals(32, result1.get());
-        Assertions.assertEquals("48", result2.get());
+        Assertions.assertEquals("48.0", result2.get());
     }
 
     private static void connectInt(Graph graph, Node a, String connectorA, Node b, String connectorB) {

--- a/core/src/test/java/club/mondaylunch/gatos/core/executor/test/GraphExecutorTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/executor/test/GraphExecutorTest.java
@@ -21,33 +21,33 @@ import club.mondaylunch.gatos.core.graph.connector.NodeConnector;
 import club.mondaylunch.gatos.core.graph.type.NodeType;
 
 public class GraphExecutorTest {
-    private static final NodeType ADD_INTS = new AddIntNodeType();
-    private static final NodeType ADD_INTS_SLOWLY = new SlowlyAddIntNodeType();
-    private static final NodeType ADD_INTS_2INPUT = new AddIntTwoInputNodeType();
-    private static final NodeType INPUT_INT = new InputIntNodeType();
+    private static final NodeType ADD_NUMS = new AddNumNodeType();
+    private static final NodeType ADD_NUMS_SLOWLY = new SlowlyAddNumNodeType();
+    private static final NodeType ADD_NUMS_2INPUT = new AddNumTwoInputNodeType();
+    private static final NodeType INPUT_NUM = new InputNumNodeType();
 
     @Test
     public void simpleGraphComputesCorrectly() {
         var graph = new Graph();
         AtomicInteger result = new AtomicInteger();
-        var input = graph.addNode(INPUT_INT);
-        graph.modifyNode(input.id(), node -> node.modifySetting("value", DataType.INTEGER.create(10)));
+        var input = graph.addNode(INPUT_NUM);
+        graph.modifyNode(input.id(), node -> node.modifySetting("value", DataType.NUMBER.create(10.)));
         var output = graph.addNode(new OutputIntNodeType(result));
 
-        var adder = graph.addNode(ADD_INTS);
-        graph.modifyNode(adder.id(), node -> node.modifySetting("value_to_add", DataType.INTEGER.create(5)));
+        var adder = graph.addNode(ADD_NUMS);
+        graph.modifyNode(adder.id(), node -> node.modifySetting("value_to_add", DataType.NUMBER.create(5.)));
 
         var conn = NodeConnection.createConnection(
                 input, "out",
                 adder, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
         conn = NodeConnection.createConnection(
                 adder, "out",
                 output, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
@@ -63,24 +63,24 @@ public class GraphExecutorTest {
     public void slowGraphComputesCorrectly() {
         var graph = new Graph();
         AtomicInteger result = new AtomicInteger();
-        var input = graph.addNode(INPUT_INT);
-        graph.modifyNode(input.id(), node -> node.modifySetting("value", DataType.INTEGER.create(10)));
+        var input = graph.addNode(INPUT_NUM);
+        graph.modifyNode(input.id(), node -> node.modifySetting("value", DataType.NUMBER.create(10.)));
         var output = graph.addNode(new OutputIntNodeType(result));
 
-        var adder = graph.addNode(ADD_INTS_SLOWLY);
-        graph.modifyNode(adder.id(), node -> node.modifySetting("value_to_add", DataType.INTEGER.create(5)));
+        var adder = graph.addNode(ADD_NUMS_SLOWLY);
+        graph.modifyNode(adder.id(), node -> node.modifySetting("value_to_add", DataType.NUMBER.create(5.)));
 
         var conn = NodeConnection.createConnection(
                 input, "out",
                 adder, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
         conn = NodeConnection.createConnection(
                 adder, "out",
                 output, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
@@ -100,16 +100,16 @@ public class GraphExecutorTest {
 
         var inputs = IntStream.of(2, 4, 8, 16, 2)
                 .mapToObj(i -> {
-                    var input = graph.addNode(INPUT_INT);
+                    var input = graph.addNode(INPUT_NUM);
                     return graph.modifyNode(input.id(),
-                            node -> node.modifySetting("value", DataType.INTEGER.create(i)));
+                            node -> node.modifySetting("value", DataType.NUMBER.create((double) i)));
                 })
                 .toList();
 
-        var adder1 = graph.addNode(ADD_INTS_2INPUT);
-        var adder2 = graph.addNode(ADD_INTS_2INPUT);
-        var adder3 = graph.addNode(ADD_INTS_2INPUT);
-        var adder4 = graph.addNode(ADD_INTS_2INPUT);
+        var adder1 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder2 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder3 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder4 = graph.addNode(ADD_NUMS_2INPUT);
 
         connectInt(graph, inputs.get(1), "out", adder1, "in1");
         connectInt(graph, inputs.get(2), "out", adder1, "in2");
@@ -143,17 +143,17 @@ public class GraphExecutorTest {
 
         var inputs = IntStream.of(2, 4, 8, 16, 2)
                 .mapToObj(i -> {
-                    var input = graph.addNode(INPUT_INT);
+                    var input = graph.addNode(INPUT_NUM);
                     return graph.modifyNode(input.id(),
-                            node -> node.modifySetting("value", DataType.INTEGER.create(i)));
+                            node -> node.modifySetting("value", DataType.NUMBER.create((double) i)));
                 })
                 .toList();
 
-        var adder1 = graph.addNode(ADD_INTS_2INPUT);
-        var adder2 = graph.addNode(ADD_INTS_2INPUT);
-        var adder3 = graph.addNode(ADD_INTS_2INPUT);
-        var adder4 = graph.addNode(ADD_INTS_2INPUT);
-        var adder5 = graph.addNode(ADD_INTS_2INPUT);
+        var adder1 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder2 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder3 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder4 = graph.addNode(ADD_NUMS_2INPUT);
+        var adder5 = graph.addNode(ADD_NUMS_2INPUT);
 
         connectInt(graph, inputs.get(1), "out", adder1, "in1");
         connectInt(graph, inputs.get(2), "out", adder1, "in2");
@@ -187,52 +187,52 @@ public class GraphExecutorTest {
         var conn = NodeConnection.createConnection(
                 a, connectorA,
                 b, connectorB,
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
     }
 
-    private static final class AddIntNodeType extends NodeType.Process {
+    private static final class AddNumNodeType extends NodeType.Process {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
         public Map<String, DataBox<?>> settings() {
             return Map.of(
-                    "value_to_add", DataType.INTEGER.create(0));
+                    "value_to_add", DataType.NUMBER.create((double) 0));
         }
 
         @Override
         public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs,
                 Map<String, DataBox<?>> settings) {
             return Map.of(
-                    "out", CompletableFuture.completedFuture(DataType.INTEGER.create(
-                            DataBox.get(settings, "value_to_add", DataType.INTEGER).orElseThrow()
-                                    + DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow())));
+                    "out", CompletableFuture.completedFuture(DataType.NUMBER.create(
+                            DataBox.get(settings, "value_to_add", DataType.NUMBER).orElseThrow()
+                                    + DataBox.get(inputs, "in", DataType.NUMBER).orElseThrow())));
         }
     }
 
-    private static final class AddIntTwoInputNodeType extends NodeType.Process {
+    private static final class AddNumTwoInputNodeType extends NodeType.Process {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in1", DataType.INTEGER),
-                    new NodeConnector.Input<>(nodeId, "in2", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in1", DataType.NUMBER),
+                    new NodeConnector.Input<>(nodeId, "in2", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
@@ -244,29 +244,29 @@ public class GraphExecutorTest {
         public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs,
                 Map<String, DataBox<?>> settings) {
             return Map.of(
-                    "out", CompletableFuture.completedFuture(DataType.INTEGER.create(
-                            DataBox.get(inputs, "in1", DataType.INTEGER).orElseThrow()
-                                    + DataBox.get(inputs, "in2", DataType.INTEGER).orElseThrow())));
+                    "out", CompletableFuture.completedFuture(DataType.NUMBER.create(
+                            DataBox.get(inputs, "in1", DataType.NUMBER).orElseThrow()
+                                    + DataBox.get(inputs, "in2", DataType.NUMBER).orElseThrow())));
         }
     }
 
-    private static final class SlowlyAddIntNodeType extends NodeType.Process {
+    private static final class SlowlyAddNumNodeType extends NodeType.Process {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
         public Map<String, DataBox<?>> settings() {
             return Map.of(
-                    "value_to_add", DataType.INTEGER.create(0));
+                    "value_to_add", DataType.NUMBER.create((double) 0));
         }
 
         @Override
@@ -274,33 +274,33 @@ public class GraphExecutorTest {
                 Map<String, DataBox<?>> settings) {
             return Map.of(
                     "out", CompletableFuture.supplyAsync(this.addIntsSlowly(
-                            DataBox.get(settings, "value_to_add", DataType.INTEGER).orElseThrow(),
-                            DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow())));
+                            DataBox.get(settings, "value_to_add", DataType.NUMBER).orElseThrow(),
+                            DataBox.get(inputs, "in", DataType.NUMBER).orElseThrow())));
         }
 
-        private Supplier<DataBox<?>> addIntsSlowly(int a, int b) {
+        private Supplier<DataBox<?>> addIntsSlowly(double a, double b) {
             return () -> {
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                return DataType.INTEGER.create(a + b);
+                return DataType.NUMBER.create(a + b);
             };
         }
     }
 
-    private static final class InputIntNodeType extends NodeType.Start {
+    private static final class InputNumNodeType extends NodeType.Start {
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
         public Map<String, DataBox<?>> settings() {
             return Map.of(
-                    "value", DataType.INTEGER.create(0));
+                    "value", DataType.NUMBER.create(0.));
         }
 
         @Override
@@ -308,7 +308,7 @@ public class GraphExecutorTest {
                 Map<String, DataBox<?>> settings) {
             return Map.of(
                     "out", CompletableFuture.completedFuture(
-                            DataType.INTEGER.create(DataBox.get(settings, "value", DataType.INTEGER).orElseThrow())));
+                            DataType.NUMBER.create(DataBox.get(settings, "value", DataType.NUMBER).orElseThrow())));
         }
     }
 
@@ -324,7 +324,7 @@ public class GraphExecutorTest {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
@@ -334,7 +334,7 @@ public class GraphExecutorTest {
 
         @Override
         public CompletableFuture<Void> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
-            this.result.set(DataBox.get(inputs, "in", DataType.INTEGER).orElseThrow());
+            this.result.set(DataBox.get(inputs, "in", DataType.NUMBER).orElseThrow().intValue());
             return CompletableFuture.runAsync(() -> {
             });
         }

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/GraphTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/GraphTest.java
@@ -45,11 +45,11 @@ public class GraphTest {
     public void canModifyNode() {
         var graph = new Graph();
         var node = graph.addNode(TEST_NODE_TYPE);
-        var modifiedNode = graph.modifyNode(node.id(), n -> n.modifySetting("setting_1", DataType.INTEGER.create(100)));
+        var modifiedNode = graph.modifyNode(node.id(), n -> n.modifySetting("setting_1", DataType.NUMBER.create(100.)));
         Assertions.assertFalse(graph.containsNode(node));
         Assertions.assertTrue(graph.containsNode(node.id()));
         Assertions.assertTrue(graph.containsNode(modifiedNode));
-        Assertions.assertEquals(100, modifiedNode.getSetting("setting_1", DataType.INTEGER).value());
+        Assertions.assertEquals(100, modifiedNode.getSetting("setting_1", DataType.NUMBER).value());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class GraphTest {
         var graph = new Graph();
         var node = graph.addNode(TEST_NODE_TYPE);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            graph.modifyNode(UUID.randomUUID(), n -> n.modifySetting("setting_1", DataType.INTEGER.create(100)));
+            graph.modifyNode(UUID.randomUUID(), n -> n.modifySetting("setting_1", DataType.NUMBER.create(100.)));
         });
     }
 
@@ -76,7 +76,7 @@ public class GraphTest {
         var node1 = graph.addNode(TEST_NODE_TYPE);
         var node2 = graph.addNode(TEST_NODE_TYPE);
 
-        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
 
         graph.addConnection(conn.get());
@@ -91,14 +91,14 @@ public class GraphTest {
         var node1 = Node.create(TEST_NODE_TYPE);
         var node2 = graph.addNode(TEST_NODE_TYPE);
 
-        var conn1 = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
+        var conn1 = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn1.isPresent());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             graph.addConnection(conn1.get());
         });
 
-        var conn2 = NodeConnection.createConnection(node2, "out", node1, "in", DataType.INTEGER);
+        var conn2 = NodeConnection.createConnection(node2, "out", node1, "in", DataType.NUMBER);
         Assertions.assertTrue(conn2.isPresent());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -113,12 +113,12 @@ public class GraphTest {
         var node2 = graph.addNode(TEST_NODE_TYPE);
         var node3 = graph.addNode(TEST_NODE_TYPE);
 
-        var conn1 = NodeConnection.createConnection(node1, "out", node3, "in", DataType.INTEGER);
+        var conn1 = NodeConnection.createConnection(node1, "out", node3, "in", DataType.NUMBER);
         Assertions.assertTrue(conn1.isPresent());
 
         graph.addConnection(conn1.get());
 
-        var conn2 = NodeConnection.createConnection(node2, "out", node3, "in", DataType.INTEGER);
+        var conn2 = NodeConnection.createConnection(node2, "out", node3, "in", DataType.NUMBER);
         Assertions.assertTrue(conn2.isPresent());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -132,7 +132,7 @@ public class GraphTest {
         var node1 = graph.addNode(TEST_NODE_TYPE);
         var node2 = graph.addNode(TEST_NODE_TYPE);
 
-        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
 
         graph.addConnection(conn.get());
@@ -148,7 +148,7 @@ public class GraphTest {
         var node1 = graph.addNode(TEST_NODE_TYPE);
         var node2 = graph.addNode(TEST_NODE_TYPE);
 
-        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
 
         graph.addConnection(conn.get());
@@ -165,7 +165,7 @@ public class GraphTest {
         var node1 = graph.addNode(TEST_NODE_TYPE);
         var node2 = graph.addNode(TEST_NODE_TYPE);
 
-        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
 
         graph.addConnection(conn.get());
@@ -217,7 +217,7 @@ public class GraphTest {
         var graph = new Graph();
         var input = graph.addNode(INPUT_NODE_TYPE);
         var output = graph.addNode(OUTPUT_NODE_TYPE);
-        var conn = NodeConnection.createConnection(input, "out", output, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(input, "out", output, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
         Assertions.assertTrue(graph.validate());
@@ -236,7 +236,7 @@ public class GraphTest {
         var graph = new Graph();
         var input = graph.addNode(TEST_NODE_TYPE);
         var output = graph.addNode(OUTPUT_NODE_TYPE);
-        var conn = NodeConnection.createConnection(input, "out", output, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(input, "out", output, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
         Assertions.assertFalse(graph.validate());
@@ -247,7 +247,7 @@ public class GraphTest {
         var graph = new Graph();
         var input = graph.addNode(INPUT_NODE_TYPE);
         var output = graph.addNode(TEST_NODE_TYPE);
-        var conn = NodeConnection.createConnection(input, "out", output, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(input, "out", output, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
         Assertions.assertFalse(graph.validate());
@@ -266,7 +266,7 @@ public class GraphTest {
             var conn = NodeConnection.createConnection(
                     lastNode == null ? input : lastNode, "out",
                     intermediary, "in",
-                    DataType.INTEGER);
+                    DataType.NUMBER);
             Assertions.assertTrue(conn.isPresent());
             graph.addConnection(conn.get());
 
@@ -276,7 +276,7 @@ public class GraphTest {
         var conn = NodeConnection.createConnection(
                 lastNode, "out",
                 output, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
@@ -296,7 +296,7 @@ public class GraphTest {
             var conn = NodeConnection.createConnection(
                     lastNode == null ? input : lastNode, "out",
                     intermediary, "in",
-                    DataType.INTEGER);
+                    DataType.NUMBER);
             Assertions.assertTrue(conn.isPresent());
             graph.addConnection(conn.get());
 
@@ -306,7 +306,7 @@ public class GraphTest {
         var conn = NodeConnection.createConnection(
                 lastNode, "out",
                 output, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
@@ -332,7 +332,7 @@ public class GraphTest {
             var conn = NodeConnection.createConnection(
                     lastNode == null ? input : lastNode, "out",
                     intermediary, "in",
-                    DataType.INTEGER);
+                    DataType.NUMBER);
             Assertions.assertTrue(conn.isPresent());
             graph.addConnection(conn.get());
 
@@ -343,7 +343,7 @@ public class GraphTest {
         var conn = NodeConnection.createConnection(
                 lastNode, "out",
                 output, "in",
-                DataType.INTEGER);
+                DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
         graph.addConnection(conn.get());
 
@@ -362,19 +362,19 @@ public class GraphTest {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
         public Map<String, DataBox<?>> settings() {
             return Map.of(
-                    "setting_1", DataType.INTEGER.create(0));
+                    "setting_1", DataType.NUMBER.create(0.));
         }
 
         @Override
@@ -388,7 +388,7 @@ public class GraphTest {
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
@@ -407,7 +407,7 @@ public class GraphTest {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeConnectionTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeConnectionTest.java
@@ -23,7 +23,7 @@ public class NodeConnectionTest {
         var node1 = Node.create(TEST_NODE_TYPE);
         var node2 = Node.create(TEST_NODE_TYPE);
 
-        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isPresent());
     }
 
@@ -32,10 +32,10 @@ public class NodeConnectionTest {
         var node1 = Node.create(TEST_NODE_TYPE);
         var node2 = Node.create(TEST_NODE_TYPE);
 
-        var conn = NodeConnection.createConnection(node1, "invalid", node2, "in", DataType.INTEGER);
+        var conn = NodeConnection.createConnection(node1, "invalid", node2, "in", DataType.NUMBER);
         Assertions.assertTrue(conn.isEmpty());
 
-        conn = NodeConnection.createConnection(node1, "out", node2, "invalid", DataType.INTEGER);
+        conn = NodeConnection.createConnection(node1, "out", node2, "invalid", DataType.NUMBER);
         Assertions.assertTrue(conn.isEmpty());
     }
 
@@ -61,13 +61,13 @@ public class NodeConnectionTest {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER),
+                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER),
                     new NodeConnector.Output<>(nodeId, "out_2", DataType.BOOLEAN));
         }
 

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeConnectionTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeConnectionTest.java
@@ -17,6 +17,7 @@ import club.mondaylunch.gatos.core.graph.type.NodeType;
 
 public class NodeConnectionTest {
     private static final NodeType TEST_NODE_TYPE = new TestNodeType();
+    private static final NodeType TEST_NODE_TYPE_2 = new TestNodeType2();
 
     @Test
     public void canCreateConnection() {
@@ -57,18 +58,28 @@ public class NodeConnectionTest {
         Assertions.assertTrue(conn.isEmpty());
     }
 
+    @Test
+    public void connectionWithConvertableTypesIsNotEmpty() {
+        var node1 = Node.create(TEST_NODE_TYPE);
+        var node2 = Node.create(TEST_NODE_TYPE_2);
+
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", DataType.STRING);
+        Assertions.assertFalse(conn.isEmpty());
+    }
+
     private static final class TestNodeType extends NodeType.Process {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
+                new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER),
-                    new NodeConnector.Output<>(nodeId, "out_2", DataType.BOOLEAN));
+                new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER),
+                new NodeConnector.Output<>(nodeId, "out_2", DataType.BOOLEAN)
+            );
         }
 
         @Override
@@ -78,7 +89,31 @@ public class NodeConnectionTest {
 
         @Override
         public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs,
-                Map<String, DataBox<?>> settings) {
+                                                                  Map<String, DataBox<?>> settings) {
+            return Map.of();
+        }
+    }
+
+    private static final class TestNodeType2 extends NodeType.Process {
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of(
+                new NodeConnector.Input<>(nodeId, "in", DataType.STRING));
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+            return Set.of();
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs,
+                                                                  Map<String, DataBox<?>> settings) {
             return Map.of();
         }
     }

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeTest.java
@@ -44,14 +44,14 @@ public class NodeTest {
     @Test
     public void canGetSettingByName() {
         var node = Node.create(TEST_NODE_TYPE);
-        Assertions.assertEquals(0, node.getSetting("setting_1", DataType.INTEGER).value());
+        Assertions.assertEquals(0, node.getSetting("setting_1", DataType.NUMBER).value());
     }
 
     @Test
     public void gettingWrongSettingThrows() {
         var node = Node.create(TEST_NODE_TYPE);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            node.getSetting("setting_3", DataType.INTEGER);
+            node.getSetting("setting_3", DataType.NUMBER);
         });
     }
 
@@ -59,23 +59,23 @@ public class NodeTest {
     public void gettingWrongTypeSettingThrows() {
         var node = Node.create(TEST_NODE_TYPE);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            node.getSetting("setting_2", DataType.INTEGER);
+            node.getSetting("setting_2", DataType.NUMBER);
         });
     }
 
     @Test
     public void canMakeNewNodeWithChangedSettings() {
         var node = Node.create(TEST_NODE_TYPE);
-        var newNode = node.modifySetting("setting_1", DataType.INTEGER.create(100));
+        var newNode = node.modifySetting("setting_1", DataType.NUMBER.create(100.));
         Assertions.assertEquals(node.id(), newNode.id());
-        Assertions.assertEquals(100, newNode.getSetting("setting_1", DataType.INTEGER).value());
+        Assertions.assertEquals(100, newNode.getSetting("setting_1", DataType.NUMBER).value());
     }
 
     @Test
     public void changingNonexistentSettingThrows() {
         var node = Node.create(TEST_NODE_TYPE);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            node.modifySetting("setting_3", DataType.INTEGER.create(100));
+            node.modifySetting("setting_3", DataType.NUMBER.create(100.));
         });
     }
 
@@ -83,7 +83,7 @@ public class NodeTest {
     public void changingWrongTypeSettingThrows() {
         var node = Node.create(TEST_NODE_TYPE);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            node.modifySetting("setting_2", DataType.INTEGER.create(100));
+            node.modifySetting("setting_2", DataType.NUMBER.create(100.));
         });
     }
 
@@ -99,16 +99,16 @@ public class NodeTest {
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
             return Set.of(
-                    new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+                    new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
-            var out = new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER);
+            var out = new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER);
             return (Boolean) state.get("setting_2").value()
                     ? Set.of(
                             out,
-                            new NodeConnector.Output<>(nodeId, "out_2", DataType.INTEGER))
+                            new NodeConnector.Output<>(nodeId, "out_2", DataType.NUMBER))
                     : Set.of(
                             out);
         }
@@ -116,7 +116,7 @@ public class NodeTest {
         @Override
         public Map<String, DataBox<?>> settings() {
             return Map.of(
-                    "setting_1", DataType.INTEGER.create(0),
+                    "setting_1", DataType.NUMBER.create(0.),
                     "setting_2", DataType.BOOLEAN.create(false));
         }
 

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/type/test/TestNodeTypes.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/type/test/TestNodeTypes.java
@@ -25,7 +25,7 @@ public class TestNodeTypes {
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
-            return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+            return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
@@ -43,12 +43,12 @@ public class TestNodeTypes {
 
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
-            return Set.of(new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+            return Set.of(new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
         public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
-            return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.INTEGER));
+            return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
         @Override
@@ -66,7 +66,7 @@ public class TestNodeTypes {
 
         @Override
         public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
-            return Set.of(new NodeConnector.Input<>(nodeId, "in", DataType.INTEGER));
+            return Set.of(new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/type/test/TestNodeTypes.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/type/test/TestNodeTypes.java
@@ -1,6 +1,8 @@
 package club.mondaylunch.gatos.core.graph.type.test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -20,7 +22,9 @@ public class TestNodeTypes {
 
         @Override
         public Map<String, DataBox<?>> settings() {
-            return Map.of();
+            return Map.of(
+                "setting", DataType.NUMBER.create(0.0)
+            );
         }
 
         @Override
@@ -38,7 +42,9 @@ public class TestNodeTypes {
 
         @Override
         public Map<String, DataBox<?>> settings() {
-            return Map.of();
+            return Map.of(
+                "setting", DataType.NUMBER.listOf().create(List.of(20.0, 3.0))
+            );
         }
 
         @Override
@@ -61,7 +67,9 @@ public class TestNodeTypes {
 
         @Override
         public Map<String, DataBox<?>> settings() {
-            return Map.of();
+            return Map.of(
+                "setting", DataType.NUMBER.optionalOf().create(Optional.of(1.5))
+            );
         }
 
         @Override


### PR DESCRIPTION
This PR:
 - Replaces INTEGER datatype with NUMBER (double)
 - Adds ANY type
 - Adds Conversions! Conversions betweeen DataTypes are registered in the Conversions class. They are transparent to the user: an A output node can be connected to a B input node like normal if there is a conversion A->B.
 - Adds a codec for DataBoxes, allowing them to be serialised to BSON.
 - Adds ListDataType and OptionalDataType. There are also generic DataTypes available for these.
 - Removes Registry.RegistryRegistry. Registry.REGISTRY is now just a Registry<Registry<?>>. :trollface: 
 - Adds some more SerializationUtils to reduce brittleness of serialisation code when startDocument/endDocuments must be matched up.