### PR TITLE
feat: add dynamic output datatypes depending on input datatype specialisation

### DIFF
--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/ListLengthNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/ListLengthNodeType.java
@@ -22,13 +22,13 @@ public class ListLengthNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
         return Set.of(
             new NodeConnector.Input<>(nodeId, "input", ListDataType.GENERIC_LIST));
     }
 
     @Override
-    public Set<Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
         return Set.of(
             new NodeConnector.Output<>(nodeId, "output", DataType.NUMBER));
     }

--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringConcatNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringConcatNodeType.java
@@ -18,13 +18,13 @@ public class StringConcatNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
         return Set.of(
             new NodeConnector.Input<>(nodeId, "input", DataType.STRING.listOf()));
     }
 
     @Override
-    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
         return Set.of(
             new NodeConnector.Output<>(nodeId, "output", DataType.STRING));
     }

--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringContainsNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringContainsNodeType.java
@@ -17,13 +17,13 @@ public class StringContainsNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
         return Set.of(
             new NodeConnector.Input<>(nodeId, "input", DataType.STRING));
     }
 
     @Override
-    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
         return Set.of(
             new NodeConnector.Output<>(nodeId, "output", DataType.BOOLEAN));
     }

--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringInterpolationNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringInterpolationNodeType.java
@@ -27,8 +27,8 @@ public class StringInterpolationNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
-        String template = DataBox.get(state, "template", DataType.STRING).orElse("");
+    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
+        String template = DataBox.get(settings, "template", DataType.STRING).orElse("");
         var matcher = PLACEHOLDER_PATTERN.matcher(template);
         var matches = matcher.results().toList();
         return matches.stream()
@@ -39,7 +39,7 @@ public class StringInterpolationNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
         return Set.of(
                 new NodeConnector.Output<>(nodeId, "result", DataType.STRING));
     }

--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringLengthNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/StringLengthNodeType.java
@@ -17,13 +17,13 @@ public class StringLengthNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
         return Set.of(
             new NodeConnector.Input<>(nodeId, "input", DataType.STRING));
     }
 
     @Override
-    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
         return Set.of(
             new NodeConnector.Output<>(nodeId, "output", DataType.NUMBER));
     }

--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/VariableExtractionNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/VariableExtractionNodeType.java
@@ -31,7 +31,7 @@ public class VariableExtractionNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
         return Set.of(
             new NodeConnector.Input<>(nodeId, "input", DataType.JSON_OBJECT),
             new NodeConnector.Input<>(nodeId, "key", DataType.STRING)
@@ -39,8 +39,8 @@ public class VariableExtractionNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
-        var returnDataType = DataBox.get(state, "output_type", RETURN_DATATYPE).orElse(ReturnType.STRING);
+    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
+        var returnDataType = DataBox.get(settings, "output_type", RETURN_DATATYPE).orElse(ReturnType.STRING);
         return returnDataType.isListType()
             ? Set.of(new NodeConnector.Output<>(nodeId, "output", returnDataType.getDataType()))
             : Set.of(new NodeConnector.Output<>(nodeId, "output", returnDataType.getDataType().optionalOf())

--- a/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/VariableRemappingNodeType.java
+++ b/basic_nodes/src/main/java/club/mondaylunch/gatos/basicnodes/VariableRemappingNodeType.java
@@ -19,7 +19,7 @@ public class VariableRemappingNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
         return Set.of(
             new NodeConnector.Input<>(nodeId, "input", DataType.JSON_OBJECT),
             new NodeConnector.Input<>(nodeId, "oldKey", DataType.STRING),
@@ -28,7 +28,7 @@ public class VariableRemappingNodeType extends NodeType.Process {
     }
 
     @Override
-    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+    public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
         return Set.of(
             new NodeConnector.Output<>(nodeId, "output", DataType.JSON_OBJECT)
         );

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
@@ -24,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import club.mondaylunch.gatos.core.codec.SerializationUtils;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnection;
+import club.mondaylunch.gatos.core.graph.connector.NodeConnector;
 import club.mondaylunch.gatos.core.graph.type.NodeCategory;
 import club.mondaylunch.gatos.core.graph.type.NodeType;
 
@@ -128,6 +130,15 @@ public class Graph {
     }
 
     /**
+     * Gets the node with a given UUID from the graph, if it exists.
+     * @param id    the UUID of the graph
+     * @return      the node with the UUID, or empty
+     */
+    public Optional<Node> getNode(UUID id) {
+        return Optional.ofNullable(this.nodes.get(id));
+    }
+
+    /**
      * Whether this <em>exact</em> node exists in the graph.
      *
      * @param node the node
@@ -172,7 +183,11 @@ public class Graph {
 
         this.connections.add(connection);
         this.getOrCreateConnectionsForNode(nodeFrom.id()).add(connection);
-        this.getOrCreateConnectionsForNode(nodeTo.id()).add(connection);
+        var destinationNodeConnections = this.getOrCreateConnectionsForNode(nodeTo.id());
+        destinationNodeConnections.add(connection);
+        this.modifyNode(nodeTo.id(), n -> n.updateInputTypes(destinationNodeConnections.stream()
+                .filter(c -> c.to().nodeId().equals(nodeTo.id()))
+            .collect(Collectors.toMap(c -> c.to().name(), c -> this.getCanonicalConnector(c.from()).type()))));
     }
 
     /**
@@ -183,7 +198,13 @@ public class Graph {
     public void removeConnection(NodeConnection<?> connection) {
         this.connections.remove(connection);
         this.getOrCreateConnectionsForNode(connection.from().nodeId()).remove(connection);
-        this.getOrCreateConnectionsForNode(connection.to().nodeId()).remove(connection);
+        var destinationNodeConnections = this.getOrCreateConnectionsForNode(connection.to().nodeId());
+        destinationNodeConnections.remove(connection);
+        if (this.containsNode(connection.to().nodeId())) {
+            this.modifyNode(connection.to().nodeId(), n -> n.updateInputTypes(destinationNodeConnections.stream()
+                    .filter(c -> c.to().nodeId().equals(connection.to().nodeId()))
+                .collect(Collectors.toMap(c -> c.to().name(), c -> this.getCanonicalConnector(c.from()).type()))));
+        }
     }
 
     /**
@@ -220,6 +241,16 @@ public class Graph {
      */
     private Set<NodeConnection<?>> getOrCreateConnectionsForNode(UUID nodeId) {
         return this.connectionsByNode.computeIfAbsent(nodeId, $ -> new HashSet<>());
+    }
+
+    /**
+     * For an output connector which may have a modified type, gets the connector with the 'true' type.
+     * If the connector does not exist, this method throws an exception.
+     * @param derivedConnector  the connector to find the canonical representation of
+     * @return  the canonical representation of the connector
+     */
+    private NodeConnector.Output<?> getCanonicalConnector(NodeConnector.Output<?> derivedConnector) {
+        return this.nodes.get(derivedConnector.nodeId()).getOutputWithName(derivedConnector.name()).orElseThrow();
     }
 
     /**
@@ -402,27 +433,27 @@ public class Graph {
 
         @Override
         public Graph decode(BsonReader reader, DecoderContext decoderContext) {
-            reader.readStartDocument();
-            reader.readName("nodes");
-            Set<Node> nodes = SerializationUtils.readSet(reader, decoderContext, Node.class, this.registry);
-            reader.readName("connections");
-            Set<NodeConnection<?>> connections = SerializationUtils.readSet(reader, decoderContext, NodeConnection.class, this.registry);
-            reader.readName("metadata");
-            Map<UUID, NodeMetadata> metadata = SerializationUtils.readMap(reader, decoderContext, NodeMetadata.class, UUID::fromString, this.registry);
-            reader.readEndDocument();
-            return new Graph(nodes, metadata, connections);
+            return SerializationUtils.readDocument(reader, () -> {
+                reader.readName("nodes");
+                Set<Node> nodes = SerializationUtils.readSet(reader, decoderContext, Node.class, this.registry);
+                reader.readName("connections");
+                Set<NodeConnection<?>> connections = SerializationUtils.readSet(reader, decoderContext, NodeConnection.class, this.registry);
+                reader.readName("metadata");
+                Map<UUID, NodeMetadata> metadata = SerializationUtils.readMap(reader, decoderContext, NodeMetadata.class, UUID::fromString, this.registry);
+                return new Graph(nodes, metadata, connections);
+            });
         }
 
         @Override
         public void encode(BsonWriter writer, Graph value, EncoderContext encoderContext) {
-            writer.writeStartDocument();
-            writer.writeName("nodes");
-            SerializationUtils.writeSet(writer, encoderContext, Node.class, this.registry, Set.copyOf(value.nodes.values()));
-            writer.writeName("connections");
-            SerializationUtils.writeSet(writer, encoderContext, NodeConnection.class, this.registry, value.connections);
-            writer.writeName("metadata");
-            SerializationUtils.writeMap(writer, encoderContext, NodeMetadata.class, UUID::toString, this.registry, value.metadataByNode);
-            writer.writeEndDocument();
+            SerializationUtils.writeDocument(writer, () -> {
+                writer.writeName("nodes");
+                SerializationUtils.writeSet(writer, encoderContext, Node.class, this.registry, Set.copyOf(value.nodes.values()));
+                writer.writeName("connections");
+                SerializationUtils.writeSet(writer, encoderContext, NodeConnection.class, this.registry, value.connections);
+                writer.writeName("metadata");
+                SerializationUtils.writeMap(writer, encoderContext, NodeMetadata.class, UUID::toString, this.registry, value.metadataByNode);
+            });
         }
 
         @Override

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/Node.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/Node.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import club.mondaylunch.gatos.core.codec.SerializationUtils;
 import club.mondaylunch.gatos.core.data.DataBox;
 import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.Conversions;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnector;
 import club.mondaylunch.gatos.core.graph.type.NodeType;
 
@@ -39,18 +40,21 @@ public final class Node {
     private final @Unmodifiable Map<String, DataBox<?>> settings;
     private final @Unmodifiable Map<String, NodeConnector.Input<?>> inputs;
     private final @Unmodifiable Map<String, NodeConnector.Output<?>> outputs;
+    private final @Unmodifiable Map<String, DataType<?>> inputTypes;
 
     private Node(
         UUID id,
         NodeType type,
         Map<String, DataBox<?>> settings,
         Set<NodeConnector.Input<?>> inputs,
-        Set<NodeConnector.Output<?>> outputs) {
+        Set<NodeConnector.Output<?>> outputs,
+        Map<String, DataType<?>> inputTypes) {
         this.id = id;
         this.type = type;
         this.settings = Map.copyOf(settings);
         this.inputs = Map.copyOf(inputs.stream().collect(Collectors.toMap(NodeConnector::name, Function.identity())));
         this.outputs = Map.copyOf(outputs.stream().collect(Collectors.toMap(NodeConnector::name, Function.identity())));
+        this.inputTypes = Map.copyOf(inputTypes);
     }
 
     /**
@@ -67,7 +71,8 @@ public final class Node {
             type,
             defaultSettings,
             NodeType.inputsOrEmpty(type, id, defaultSettings),
-            NodeType.outputsOrEmpty(type, id, defaultSettings));
+            NodeType.outputsOrEmpty(type, id, defaultSettings, Map.of()),
+            Map.of());
     }
 
     /**
@@ -89,15 +94,32 @@ public final class Node {
         }
 
         var newSettings = new HashMap<>(this.settings);
-
         newSettings.put(settingKey, value);
-
+        var newInputs = NodeType.inputsOrEmpty(this.type, this.id, newSettings);
+        var newInputTypes = filterValidInputTypes(this.inputTypes, newInputs.stream().collect(Collectors.toMap(NodeConnector::name, Function.identity())));
         return new Node(
             this.id,
             this.type,
             newSettings,
-            NodeType.inputsOrEmpty(this.type, this.id, newSettings),
-            NodeType.outputsOrEmpty(this.type, this.id, newSettings));
+            newInputs,
+            NodeType.outputsOrEmpty(this.type, this.id, newSettings, newInputTypes),
+            newInputTypes);
+    }
+
+    /**
+     * Create a new node, the same as this one, but with possibly-changed outputs due to different input types.
+     *
+     * @param newInputTypes the canonical types of each input connection
+     * @return the new node
+     */
+    public Node updateInputTypes(Map<String, DataType<?>> newInputTypes) {
+        return new Node(
+            this.id,
+            this.type,
+            this.settings,
+            Set.copyOf(this.inputs.values()),
+            NodeType.outputsOrEmpty(this.type, this.id, this.settings, newInputTypes),
+            newInputTypes);
     }
 
     /**
@@ -217,12 +239,26 @@ public final class Node {
 
     @Override
     public String toString() {
-        return "Node[id=%s, type=%s, settings=%s, inputs=%s, outputs=%s]".formatted(
+        return "Node[id=%s, type=%s, settings=%s, inputs=%s, outputs=%s, inputTypes=%s]".formatted(
             this.id,
             this.type,
             this.settings,
             this.inputs,
-            this.outputs);
+            this.outputs,
+            this.inputTypes);
+    }
+
+    /**
+     * Filters out map entries where the datatype value is not convertable to the type of the input connector specified by the key.
+     * @param oldInputTypes the input types to filter
+     * @param newInputs     the inputs of the node
+     * @return              a filtered input type map
+     */
+    private static Map<String, DataType<?>> filterValidInputTypes(Map<String, DataType<?>> oldInputTypes, Map<String, NodeConnector.Input<?>> newInputs) {
+        return oldInputTypes.entrySet().stream()
+            .filter(kv -> newInputs.containsKey(kv.getKey()))
+            .filter(kv -> Conversions.canConvert(kv.getValue(), newInputs.get(kv.getKey()).type()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public static final class NodeCodec implements Codec<Node> {
@@ -234,33 +270,39 @@ public final class Node {
 
         @Override
         public Node decode(BsonReader reader, DecoderContext decoderContext) {
-            reader.readStartDocument();
-            reader.readName("id");
-            UUID id = decoderContext.decodeWithChildContext(this.registry.get(UUID.class), reader);
-            reader.readName("type");
-            NodeType type = decoderContext.decodeWithChildContext(this.registry.get(NodeType.class), reader);
-            reader.readName("settings");
-            Map<String, DataBox<?>> settings = SerializationUtils.readMap(reader, decoderContext, DataBox.class, Function.identity(), this.registry);
-            reader.readEndDocument();
-            return new Node(
-                id,
-                type,
-                settings,
-                NodeType.inputsOrEmpty(type, id, settings),
-                NodeType.outputsOrEmpty(type, id, settings)
-            );
+            return SerializationUtils.readDocument(reader, () -> {
+                reader.readName("id");
+                UUID id = decoderContext.decodeWithChildContext(this.registry.get(UUID.class), reader);
+                reader.readName("type");
+                NodeType type = decoderContext.decodeWithChildContext(this.registry.get(NodeType.class), reader);
+                reader.readName("settings");
+                Map<String, DataBox<?>> settings = SerializationUtils.readMap(reader, decoderContext, DataBox.class, Function.identity(), this.registry);
+                reader.readName("inputTypes");
+                Map<String, DataType<?>> inputTypes = SerializationUtils.readMap(reader, decoderContext, DataType.class, Function.identity(), this.registry);
+                var inputs = NodeType.inputsOrEmpty(type, id, settings);
+                return new Node(
+                    id,
+                    type,
+                    settings,
+                    inputs,
+                    NodeType.outputsOrEmpty(type, id, settings, Map.of()),
+                    filterValidInputTypes(inputTypes, inputs.stream().collect(Collectors.toMap(NodeConnector::name, Function.identity())))
+                );
+            });
         }
 
         @Override
         public void encode(BsonWriter writer, Node value, EncoderContext encoderContext) {
-            writer.writeStartDocument();
-            writer.writeName("id");
-            encoderContext.encodeWithChildContext(this.registry.get(UUID.class), writer, value.id);
-            writer.writeName("type");
-            encoderContext.encodeWithChildContext(this.registry.get(NodeType.class), writer, value.type);
-            writer.writeName("settings");
-            SerializationUtils.writeMap(writer, encoderContext, DataBox.class, Function.identity(), this.registry, value.settings);
-            writer.writeEndDocument();
+            SerializationUtils.writeDocument(writer, () -> {
+                writer.writeName("id");
+                encoderContext.encodeWithChildContext(this.registry.get(UUID.class), writer, value.id);
+                writer.writeName("type");
+                encoderContext.encodeWithChildContext(this.registry.get(NodeType.class), writer, value.type);
+                writer.writeName("settings");
+                SerializationUtils.writeMap(writer, encoderContext, DataBox.class, Function.identity(), this.registry, value.settings);
+                writer.writeName("inputTypes");
+                SerializationUtils.writeMap(writer, encoderContext, DataType.class, Function.identity(), this.registry, value.inputTypes);
+            });
         }
 
         @Override

--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/type/NodeType.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/type/NodeType.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import club.mondaylunch.gatos.core.Registry;
 import club.mondaylunch.gatos.core.data.DataBox;
+import club.mondaylunch.gatos.core.data.DataType;
 import club.mondaylunch.gatos.core.graph.connector.NodeConnector;
 
 /**
@@ -57,12 +58,12 @@ public interface NodeType {
     @ApiStatus.NonExtendable
     interface WithInputs {
         /**
-         * The input connectors of a node with a given UUID & settings state.
+         * The input connectors of a node with a given UUID & settings.
          * @param nodeId the node UUID
-         * @param state  the node settings
+         * @param settings  the node settings
          * @return the input connectors of the node
          */
-        Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state);
+        Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings);
     }
 
     /**
@@ -71,12 +72,13 @@ public interface NodeType {
     @ApiStatus.NonExtendable
     interface WithOutputs {
         /**
-         * The output connectors of a node with a given UUID & settings state.
+         * The output connectors of a node with a given UUID, settings, & input connections.
          * @param nodeId the node UUID
-         * @param state  the node settings
+         * @param settings  the node settings
+         * @param inputTypes what type of output connector the input connectors to this node are connected to, if any
          * @return the output connectors of the node
          */
-        Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state);
+        Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes);
 
         /**
          * (Asynchronously) compute the outputs of this node in a map of output
@@ -133,11 +135,11 @@ public interface NodeType {
      * inputs.
      * @param type  the node type
      * @param id    the UUID of the node these inputs are for
-     * @param state the settings state of the node these inputs are for
+     * @param settings the settings of the node these inputs are for
      * @return the inputs, or empty
      */
-    static Set<NodeConnector.Input<?>> inputsOrEmpty(NodeType type, UUID id, Map<String, DataBox<?>> state) {
-        return type instanceof WithInputs inputType ? inputType.inputs(id, state) : Set.of();
+    static Set<NodeConnector.Input<?>> inputsOrEmpty(NodeType type, UUID id, Map<String, DataBox<?>> settings) {
+        return type instanceof WithInputs inputType ? inputType.inputs(id, settings) : Set.of();
     }
 
     /**
@@ -145,10 +147,11 @@ public interface NodeType {
      * outputs.
      * @param type  the node type
      * @param id    the UUID of the node these outputs are for
-     * @param state the settings state of the node these outputs are for
+     * @param settings the settings of the node these outputs are for
+     * @param inputTypes what type of output connector the input connectors to the node are connected to, if any
      * @return the outputs, or empty
      */
-    static Set<NodeConnector.Output<?>> outputsOrEmpty(NodeType type, UUID id, Map<String, DataBox<?>> state) {
-        return type instanceof WithOutputs outputType ? outputType.outputs(id, state) : Set.of();
+    static Set<NodeConnector.Output<?>> outputsOrEmpty(NodeType type, UUID id, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
+        return type instanceof WithOutputs outputType ? outputType.outputs(id, settings, inputTypes) : Set.of();
     }
 }

--- a/core/src/test/java/club/mondaylunch/gatos/core/executor/test/GraphExecutorTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/executor/test/GraphExecutorTest.java
@@ -254,13 +254,13 @@ public class GraphExecutorTest {
 
     private static final class AddNumNodeType extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                     new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
@@ -283,14 +283,14 @@ public class GraphExecutorTest {
 
     private static final class AddNumTwoInputNodeType extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in1", DataType.NUMBER),
                     new NodeConnector.Input<>(nodeId, "in2", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                     new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
@@ -312,13 +312,13 @@ public class GraphExecutorTest {
 
     private static final class SlowlyAddNumNodeType extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                     new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
@@ -352,7 +352,7 @@ public class GraphExecutorTest {
 
     private static final class InputNumNodeType extends NodeType.Start {
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                     new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
@@ -382,7 +382,7 @@ public class GraphExecutorTest {
         }
 
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
@@ -410,7 +410,7 @@ public class GraphExecutorTest {
         }
 
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                 new NodeConnector.Input<>(nodeId, "in", DataType.STRING));
         }

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/GraphTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/GraphTest.java
@@ -7,13 +7,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import club.mondaylunch.gatos.core.data.OptionalDataType;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import club.mondaylunch.gatos.core.data.DataBox;
 import club.mondaylunch.gatos.core.data.DataType;
+import club.mondaylunch.gatos.core.data.OptionalDataType;
 import club.mondaylunch.gatos.core.graph.Graph;
 import club.mondaylunch.gatos.core.graph.Node;
 import club.mondaylunch.gatos.core.graph.NodeMetadata;
@@ -454,7 +454,7 @@ public class GraphTest {
             if (inputOptType == OptionalDataType.GENERIC_OPTIONAL) {
                 outType = DataType.ANY;
             } else {
-                outType = ((OptionalDataType<?>)inputOptType).contains();
+                outType = ((OptionalDataType<?>) inputOptType).contains();
             }
             return Set.of(
                 new NodeConnector.Output<>(nodeId, "out", outType));

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/GraphTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/GraphTest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import club.mondaylunch.gatos.core.data.OptionalDataType;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,8 @@ public class GraphTest {
     private static final NodeType TEST_NODE_TYPE = new TestNodeType();
     private static final NodeType INPUT_NODE_TYPE = new TestInputNodeType();
     private static final NodeType OUTPUT_NODE_TYPE = new TestOutputNodeType();
+    private static final NodeType TEST_VARYING_OUTPUT_NODE_TYPE = new TestVaryingOutputNodeType();
+    private static final NodeType TEST_STRING_OPT_START_NODE_TYPE = new TestStringOptStartDataType();
 
     @Test
     public void canAddNodeToGraph() {
@@ -174,6 +177,21 @@ public class GraphTest {
 
         Assertions.assertFalse(graph.getConnectionsForNode(node1.id()).contains(conn.get()));
         Assertions.assertFalse(graph.getConnectionsForNode(node2.id()).contains(conn.get()));
+    }
+
+    @Test
+    public void makingConnectionWithSpecificTypeChangesOutputType() {
+        var graph = new Graph();
+        var node1 = graph.addNode(TEST_STRING_OPT_START_NODE_TYPE);
+        var node2 = graph.addNode(TEST_VARYING_OUTPUT_NODE_TYPE);
+
+        Assertions.assertEquals(DataType.ANY, node2.getOutputs().get("out").type());
+        var conn = NodeConnection.createConnection(node1, "out", node2, "in", OptionalDataType.GENERIC_OPTIONAL);
+        Assertions.assertTrue(conn.isPresent());
+        graph.addConnection(conn.get());
+        Assertions.assertEquals(DataType.STRING, graph.getNode(node2.id()).orElseThrow().getOutputs().get("out").type());
+        graph.removeConnection(conn.get());
+        Assertions.assertEquals(DataType.ANY, graph.getNode(node2.id()).orElseThrow().getOutputs().get("out").type());
     }
 
     @Test
@@ -360,13 +378,13 @@ public class GraphTest {
 
     private static final class TestNodeType extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                     new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
@@ -386,7 +404,7 @@ public class GraphTest {
 
     private static final class TestInputNodeType extends NodeType.Start {
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                     new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
@@ -405,7 +423,7 @@ public class GraphTest {
 
     private static final class TestOutputNodeType extends NodeType.End {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
@@ -419,6 +437,56 @@ public class GraphTest {
         public CompletableFuture<Void> compute(Map<String, DataBox<?>> inputs, Map<String, DataBox<?>> settings) {
             return CompletableFuture.runAsync(() -> {
             });
+        }
+    }
+
+    private static final class TestVaryingOutputNodeType extends NodeType.Process {
+        @Override
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
+            return Set.of(
+                new NodeConnector.Input<>(nodeId, "in", OptionalDataType.GENERIC_OPTIONAL));
+        }
+
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
+            var inputOptType = inputTypes.getOrDefault("in", OptionalDataType.GENERIC_OPTIONAL);
+            DataType<?> outType;
+            if (inputOptType == OptionalDataType.GENERIC_OPTIONAL) {
+                outType = DataType.ANY;
+            } else {
+                outType = ((OptionalDataType<?>)inputOptType).contains();
+            }
+            return Set.of(
+                new NodeConnector.Output<>(nodeId, "out", outType));
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs,
+                                                                  Map<String, DataBox<?>> settings) {
+            return Map.of();
+        }
+    }
+
+    private static final class TestStringOptStartDataType extends NodeType.Start {
+        @Override
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
+            return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.STRING.optionalOf()));
+        }
+
+        @Override
+        public Map<String, DataBox<?>> settings() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, CompletableFuture<DataBox<?>>> compute(Map<String, DataBox<?>> inputs,
+                                                                  Map<String, DataBox<?>> settings) {
+            return Map.of();
         }
     }
 }

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeConnectionTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeConnectionTest.java
@@ -69,13 +69,13 @@ public class NodeConnectionTest {
 
     private static final class TestNodeType extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                 new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(
                 new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER),
                 new NodeConnector.Output<>(nodeId, "out_2", DataType.BOOLEAN)
@@ -96,13 +96,13 @@ public class NodeConnectionTest {
 
     private static final class TestNodeType2 extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                 new NodeConnector.Input<>(nodeId, "in", DataType.STRING));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of();
         }
 

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeTest.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/test/NodeTest.java
@@ -97,15 +97,15 @@ public class NodeTest {
 
     private static final class TestNodeType extends NodeType.Process {
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(
                     new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             var out = new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER);
-            return (Boolean) state.get("setting_2").value()
+            return (Boolean) settings.get("setting_2").value()
                     ? Set.of(
                             out,
                             new NodeConnector.Output<>(nodeId, "out_2", DataType.NUMBER))

--- a/core/src/test/java/club/mondaylunch/gatos/core/graph/type/test/TestNodeTypes.java
+++ b/core/src/test/java/club/mondaylunch/gatos/core/graph/type/test/TestNodeTypes.java
@@ -28,7 +28,7 @@ public class TestNodeTypes {
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
@@ -48,12 +48,12 @@ public class TestNodeTypes {
         }
 
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 
         @Override
-        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Output<?>> outputs(UUID nodeId, Map<String, DataBox<?>> settings, Map<String, DataType<?>> inputTypes) {
             return Set.of(new NodeConnector.Output<>(nodeId, "out", DataType.NUMBER));
         }
 
@@ -73,7 +73,7 @@ public class TestNodeTypes {
         }
 
         @Override
-        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> state) {
+        public Set<NodeConnector.Input<?>> inputs(UUID nodeId, Map<String, DataBox<?>> settings) {
             return Set.of(new NodeConnector.Input<>(nodeId, "in", DataType.NUMBER));
         }
 


### PR DESCRIPTION
Before, output type could not depend on input connection types:
![image](https://user-images.githubusercontent.com/5115825/220714734-f065f6ee-7c6b-478b-9b53-574582649ef8.png)

Now, it can:
![image](https://user-images.githubusercontent.com/5115825/220715147-a360fff5-080c-4147-98de-ab3904c14cb4.png)

Note that this is based on input connection _types_, not _values_, so types are still all static :)