### PR TITLE
fix: UUID comparison with == instead of .equals causing duplicate nodes in graph execution sort

### DIFF
--- a/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
+++ b/core/src/main/java/club/mondaylunch/gatos/core/graph/Graph.java
@@ -461,7 +461,8 @@ public class Graph {
                     UUID to = conn.to().nodeId();
                     if (this.getConnectionsForNode(to).stream()
                         .filter(deduplicatedConnections::contains)
-                        .noneMatch(c -> !visitedConnections.contains(c) && c.to().nodeId() == to)) {
+                        .filter(c -> c.to().nodeId().equals(to))
+                        .allMatch(visitedConnections::contains)) {
                         nodesWithoutIncoming.add(to);
                     }
                 }


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/5115825/226964928-8b1b250e-8bd7-4623-adf3-4d099b06714c.png)

after:
![image](https://user-images.githubusercontent.com/5115825/226964974-e5ecbc1c-f9c6-456a-887c-d56f889e8f67.png)
